### PR TITLE
Convert AP Item Name to ItemChanger item name during ScoutAllLocations

### DIFF
--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -349,11 +349,23 @@ internal class Archipelago
 		ScoutedPlacements = [.. (await Session.Locations.ScoutLocationsAsync(
 			Session.Locations.AllLocations.ToArray()
 		)).Select(kvp => new ItemRandomizer.ItemPlacement(
-			kvp.Value.ItemDisplayName,
+			APItemNameToDDItemName(kvp.Value),
 			Locations.locationData.First(entry => entry.apLocationId == kvp.Value.LocationId).itemChangerName,
 			kvp.Value.Player.Name,
 			kvp.Value.Player != CurrentPlayer
 		))];
+	}
+
+	private string APItemNameToDDItemName(ScoutedItemInfo scoutedItemInfo)
+	{
+		if (scoutedItemInfo.ItemGame == "Death's Door")
+		{
+			return Items.itemData.First(entry => entry.apItemId == scoutedItemInfo.ItemId).itemChangerName;
+		}
+		else
+		{
+			return scoutedItemInfo.ItemDisplayName;
+		}
 	}
 
 	private bool CanPlayerReceiveItems()


### PR DESCRIPTION
I caught one more missed place where AP item names were used directly.

In the future, I should probably write two helpers, one for items and one for locations, to reduce the reduplicated code.