### PR TITLE
Refactor Saving and Loading of APSaveData

### DIFF
--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -166,7 +166,7 @@ internal class Archipelago
 	private async Task OnSocketOpened(LoginSuccessful loginSuccess, APSaveData apSaveData)
 	{
 		slotData = loginSuccess.SlotData;
-		itemIndex = TitleScreen.instance.saveMenu.saveSlots[TitleScreen.instance.index].saveFile.GetCountKey("AP_ItemsReceived");
+		itemIndex = TitleScreen.instance.saveMenu.saveSlots[TitleScreen.instance.saveMenu.index].saveFile.GetCountKey("AP_ItemsReceived");
 		checkItemsReceived = CheckItemsReceieved();
 		incomingItemHandler = IncomingItemHandler();
 		outgoingItemHandler = OutgoingItemHandler();

--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -3,6 +3,7 @@ using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.Helpers;
 using Archipelago.MultiClient.Net.Models;
 using Archipelago.MultiClient.Net.Packets;
+using HarmonyLib;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -401,7 +402,8 @@ internal class Archipelago
 
 		public void Erase()
 		{
-			File.Delete(GetAPSaveDataPath(SaveSlotIndex));
+			string path = GetAPSaveDataPath(SaveSlotIndex);
+			if (File.Exists(path)) { File.Delete(path); }
 		}
 
 		public void AddCheckedLocation(string location)
@@ -411,4 +413,16 @@ internal class Archipelago
 		}
 	}
 #nullable disable
+
+	[HarmonyPatch]
+	private class Patches
+	{
+		[HarmonyPostfix]
+		[HarmonyPatch(typeof(SaveSlot), nameof(SaveSlot.EraseSave))]
+		private static void Postfix(SaveSlot __instance)
+		{
+			Logger.Log(__instance.saveId);
+			Instance.ClearAPSaveSlot(int.Parse(__instance.saveId.Substring(__instance.saveId.Length-1)));
+		}
+	}
 }

--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -21,8 +21,16 @@ internal class Archipelago
 	public static event Action OnConnected;
 	public static event Action OnDisconnected;
 	private static readonly Archipelago instance = new();
-	private readonly string apSaveDataPath = $"{Application.persistentDataPath}/SAVEDATA/Save_slot#-Archipelago.json";
-	private APSaveData apSaveData;
+	private APSaveData apSaveSlot1Data = APSaveData.Load(1);
+	private APSaveData apSaveSlot2Data = APSaveData.Load(2);
+	private APSaveData apSaveSlot3Data = APSaveData.Load(3);
+	private APSaveData GetAPSaveDataForSlot(int saveIndex) => saveIndex switch
+	{
+		1 => apSaveSlot1Data,
+		2 => apSaveSlot2Data,
+		3 => apSaveSlot3Data,
+		_ => throw new IndexOutOfRangeException("Invalid save index"),
+	};
 	private UIManager uiManager;
 	private Dictionary<string, object> slotData;
 	private IEnumerator checkItemsReceived;
@@ -116,7 +124,7 @@ internal class Archipelago
 		if (!isConnected)
 		{
 			return;
-		}		
+		}
 
 		long locationId = Locations.locationData.First(entry => entry.itemChangerName == locationName).apLocationId;
 		Session.Locations.CompleteLocationChecks(locationId);
@@ -139,28 +147,7 @@ internal class Archipelago
 	public APSaveData GetAPSaveData()
 	{
 		int saveIndex = GetSaveIndex();
-
-		if (apSaveData == null)
-		{
-			string path = apSaveDataPath.Replace("#", (saveIndex).ToString());
-			if (File.Exists(path))
-			{
-				string json = File.ReadAllText(path);
-				apSaveData = JsonConvert.DeserializeObject<APSaveData>(json);
-			}
-			else
-			{
-				apSaveData = new APSaveData();
-				apSaveData.CreateEmptySave();
-			}	
-		}
-
-		if (apSaveData == null)
-		{
-			Logger.LogError($"Failed to find AP connection apSaveData save file for slot {saveIndex}:");
-		}
-
-		return apSaveData;
+		return GetAPSaveDataForSlot(saveIndex);
 	}
 
 	public T GetSlotData<T>(string key)
@@ -186,7 +173,7 @@ internal class Archipelago
 		incomingItems = new ConcurrentQueue<(ItemInfo item, int index)>();
 		outgoingItems = new ConcurrentQueue<ItemInfo>();
 		Session.Socket.SocketClosed += OnSocketClosed;
-		SaveAPData(apSaveData);
+		apSaveData.Save();
 
 		Logger.Log("Slot data:");
 		foreach (KeyValuePair<string, object> kvp in slotData)
@@ -223,6 +210,7 @@ internal class Archipelago
 
 	private void SyncLocationsChecked(APSaveData apSaveData)
 	{
+		// TODO: Fix this to account for collect (need to check location names against server, rather than purely count)
 		int locationsCheckedOnServer = Session.Locations.AllLocationsChecked.Count;
 		int locationsCheckedOnSave = apSaveData.LocationsChecked.Count;
 
@@ -309,41 +297,6 @@ internal class Archipelago
 		}
 	}
 
-	private void SaveAPData(APSaveData data)
-	{
-		string path = GetAPSaveDataPath();
-
-		// Create file
-		if (!File.Exists(path))
-		{
-			string json = JsonConvert.SerializeObject(data, Formatting.Indented);
-			File.WriteAllText(path, json);
-			Logger.Log($"Created AP save data file at: {path}");
-		}
-		// Update connection info
-		else
-		{
-			apSaveData.UpdateConnectionInfo(data);
-
-			if (Session.Locations.AllLocationsChecked.Count < 1)
-			{
-				apSaveData.ClearLocationsChecked();
-			}
-			else if (data.LocationsChecked.Count < 1)
-			{
-				foreach (long checkedLocationId in Session.Locations.AllLocationsChecked)
-				{
-					string checkedLocationName = Session.Locations.GetLocationNameFromId(checkedLocationId);
-					apSaveData.AddCheckedLocation(checkedLocationName);
-				}
-			}
-
-			Logger.Log($"Updated AP save data file at: {path}");
-		}
-
-		apSaveData = data;
-	}
-
 	private async Task ScoutAllLocations()
 	{
 		ScoutedPlacements = [.. (await Session.Locations.ScoutLocationsAsync(
@@ -378,10 +331,7 @@ internal class Archipelago
 		);
 	}
 
-	private string GetAPSaveDataPath()
-	{
-		return apSaveDataPath.Replace("#", GetSaveIndex().ToString());
-	}
+	private static string GetAPSaveDataPath(int saveIndex) => $"{Application.persistentDataPath}/SAVEDATA/Save_slot{saveIndex}-Archipelago.json";
 
 	private int GetSaveIndex()
 	{
@@ -390,85 +340,75 @@ internal class Archipelago
 			: int.Parse(GameSave.currentSave.saveId.Substring(4));
 	}
 
+	public void ClearAPSaveSlot(int saveIndex)
+	{
+		GetAPSaveDataForSlot(saveIndex).Erase();
+		switch (saveIndex)
+		{
+			case 1: apSaveSlot1Data = new(1); break;
+			case 2: apSaveSlot2Data = new(2); break;
+			case 3: apSaveSlot3Data = new(3); break;
+			default: throw new IndexOutOfRangeException("Invalid save index");
+		}
+	}
+
+#nullable enable
 	public class APSaveData
 	{
-		public string URL { get; set; }
+		public string URL { get; set; } = "";
 		public int Port { get; set; }
-		public string SlotName { get; set; }
-		public string Password { get; set; }
-		public List<string> LocationsChecked
+		public string SlotName { get; set; } = "";
+		public string Password { get; set; } = "";
+		public int SaveSlotIndex { get; }
+		public List<string> LocationsChecked { get; } = [];
+
+		public APSaveData(int saveIndex)
 		{
-			get
+			SaveSlotIndex = saveIndex;
+		}
+
+		public void Save()
+		{
+			string path = GetAPSaveDataPath(SaveSlotIndex);
+
+			// Create file
+			string json = JsonConvert.SerializeObject(this, Formatting.Indented);
+			File.WriteAllText(path, json);
+			Logger.Log($"Saved AP save data file at: {path}");
+		}
+
+		public static APSaveData Load(int saveIndex)
+		{
+			string path = GetAPSaveDataPath(saveIndex);
+
+			APSaveData? apSaveData = null;
+
+			// Create file
+			if (File.Exists(path))
 			{
-				JObject jObject = GetJSONObject();
-				return jObject[nameof(LocationsChecked)]?.ToObject<List<string>>();
+				string json = File.ReadAllText(path);
+				apSaveData = JsonConvert.DeserializeObject<APSaveData>(json);
+			}
+			if (apSaveData == null)
+			{
+				return new APSaveData(saveIndex);
+			}
+			else
+			{
+				return apSaveData;
 			}
 		}
 
-		public void CreateEmptySave()
+		public void Erase()
 		{
-			JObject jObject = [];
-			jObject[nameof(LocationsChecked)] = new JArray();
-			UpdateJSON(jObject);
-		}
-
-		public void UpdateConnectionInfo(APSaveData data)
-		{
-			JObject jObject = GetJSONObject();
-
-			if (jObject.Value<string>(nameof(URL)) != data.URL)
-			{
-				jObject[nameof(URL)] = data.URL;
-			}
-
-			if (jObject.Value<int>(nameof(Port)) != data.Port)
-			{
-				jObject[nameof(Port)] = data.Port;
-			}
-
-			if (jObject.Value<string>(nameof(SlotName)) != data.SlotName)
-			{
-				jObject[nameof(SlotName)] = data.SlotName;
-			}
-
-			if (jObject.Value<string>(nameof(Password)) != data.Password)
-			{
-				jObject[nameof(Password)] = data.Password;
-			}
-
-			UpdateJSON(jObject);
+			File.Delete(GetAPSaveDataPath(SaveSlotIndex));
 		}
 
 		public void AddCheckedLocation(string location)
 		{
-			JObject jObject = GetJSONObject();
-			JArray jArray = (JArray)jObject[nameof(LocationsChecked)];
-			jArray.Add(location);
-			UpdateJSON(jObject);
-		}
-
-		public void ClearLocationsChecked()
-		{
-			LocationsChecked.Clear();
-			JObject jObject = GetJSONObject();
-			jObject[nameof(LocationsChecked)] = new JArray();
-			UpdateJSON(jObject);
-		}
-
-		private void UpdateJSON(JObject jObject)
-		{
-			using StreamWriter sw = new StreamWriter(instance.GetAPSaveDataPath());
-			using (JsonTextWriter jtw = new JsonTextWriter(sw) { Formatting = Formatting.Indented })
-			{
-				jObject.WriteTo(jtw);
-			}
-		}
-
-		private JObject GetJSONObject()
-		{
-			string apSaveDataPath = instance.GetAPSaveDataPath();
-			string json = File.ReadAllText(apSaveDataPath);
-			return JObject.Parse(json);
+			LocationsChecked.Add(location);
+			Save();
 		}
 	}
+#nullable disable
 }

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -102,14 +102,14 @@ internal class ConnectionMenu : CustomUI
 			UIManager.Instance.ShowNotification("You must specify a URL, player name, and a port number!");
 			return;
 		}
+		// TODO: Here's where we reject if the saved data has the wrong seed (and possibly other validation?)
 
-		Archipelago.APSaveData connectionInfo = new()
-		{
-			URL = url,
-			Port = port,
-			SlotName = slotName,
-			Password = password
-		};
+		Archipelago.APSaveData connectionInfo = Archipelago.Instance.GetAPSaveData();
+		connectionInfo.URL = url;
+		connectionInfo.Port = port;
+		connectionInfo.SlotName = slotName;
+		connectionInfo.Password = password;
+
 		ArchipelagoRandomizerMod.Instance.EnableMod(connectionInfo);
 	}
 


### PR DESCRIPTION
Refactor the APSaveData class to not directly manipulate JObjects, but instead use Newtonsoft Json (which is used by Archipelago.Multiclient.Net and ItemChanger) to serialize and deserialize the save data. This refactoring should make it easier to avoid json manipulation and usage errors.

This PR also includes erasing the Archipelago save data when erasing a save, and a small fix to the save slot referenced in OnSocketOpened.