### PR TITLE
Validate save data seed with server

### DIFF
--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -84,6 +84,15 @@ internal class Archipelago
 				uiManager.ShowNotification(message);
 				throw new LoginValidationException(message);
 			case LoginSuccessful success:
+
+				if (apSaveData.Seed != "" && apSaveData.Seed != Session.RoomState.Seed)
+				{
+					// Reject if the saved data has the wrong seed (TODO: possibly other validation?)
+
+					message = $"Failed to connect to Archipelago: Saved data has a different seed than the server. Each new room needs a new save.";
+					uiManager.ShowNotification(message);
+					throw new LoginValidationException(message);
+				}
 				await OnSocketOpened(success, apSaveData);
 				Logger.Log($"Successfully connected to Archipelago at {apSaveData.URL}:{apSaveData.Port} as {apSaveData.SlotName} on team {success.Team}. Have fun!");
 				return success;

--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -174,6 +174,7 @@ internal class Archipelago
 		incomingItems = new ConcurrentQueue<(ItemInfo item, int index)>();
 		outgoingItems = new ConcurrentQueue<ItemInfo>();
 		Session.Socket.SocketClosed += OnSocketClosed;
+		apSaveData.Seed = Session.RoomState.Seed;
 		apSaveData.Save();
 
 		Logger.Log("Slot data:");
@@ -361,6 +362,7 @@ internal class Archipelago
 		public string SlotName { get; set; } = "";
 		public string Password { get; set; } = "";
 		public int SaveSlotIndex { get; }
+		public string Seed { get; set; } = "";
 		public List<string> LocationsChecked { get; } = [];
 
 		public APSaveData(int saveIndex)

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -102,7 +102,6 @@ internal class ConnectionMenu : CustomUI
 			UIManager.Instance.ShowNotification("You must specify a URL, player name, and a port number!");
 			return;
 		}
-		// TODO: Here's where we reject if the saved data has the wrong seed (and possibly other validation?)
 
 		Archipelago.APSaveData connectionInfo = Archipelago.Instance.GetAPSaveData();
 		connectionInfo.URL = url;


### PR DESCRIPTION
Depends on #5 

Adds seed to APSaveData and validates the seed data with the server's seed.
Prevents connecting to rooms of the wrong seed.

This check cannot prevent connecting to a new room that is created from the same seed--the best way to do that validation is by comparing the number of items received on the file to the server, and if the local file has received more items, reject the connection. However, there's many circumstances that won't catch, and for now, I'm not worrying about it.