### PR TITLE
Trigger ItemRandomizer's PlaceItems after ItemChanger load

### DIFF
--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -32,6 +32,7 @@ internal class Archipelago
 	private ConcurrentQueue<ItemInfo> outgoingItems;
 	private int itemIndex;
 	private bool isConnected;
+	internal bool IsConnected() => isConnected;
 	private bool hasCompleted;
 	private readonly float itemReceiveDelay = 3f;
 

--- a/ArchipelagoRandomizer/ItemRandomizer.cs
+++ b/ArchipelagoRandomizer/ItemRandomizer.cs
@@ -198,7 +198,10 @@ internal class ItemRandomizer : MonoBehaviour
 		[HarmonyAfter("deathsdoor.itemchanger")] // Needs to go after ItemChanger has loaded its save
 		private static void LoadFilePatch()
 		{
-			instance.PlaceItems();
+			if (Archipelago.Instance.IsConnected())
+			{
+				instance.PlaceItems();
+			}
 		}
 
 	}


### PR DESCRIPTION
Queue the ItemRandomizer's PlaceItems to run after ItemChanger has had a chance to load its save data.

If the ItemChanger save data already exists, then the save file already exists and we should not overwrite the placements, etc.

This resolves many of the issues with RecentItemsDisplay displaying old items received.