### PR TITLE
Handle item being sent from server

### DIFF
--- a/ArchipelagoRandomizer/Items.cs
+++ b/ArchipelagoRandomizer/Items.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using Archipelago.MultiClient.Net.Models;
 using Newtonsoft.Json;
 
 namespace DDoor.ArchipelagoRandomizer;
@@ -20,12 +23,31 @@ public static class Items
         public readonly long apItemId = apItemId;
     }
 
-    public static List<Item> itemData;
+    private static List<Item> itemData;
 
     private static void PopulateItemsFromJson()
     {
         Assembly assembly = Assembly.GetExecutingAssembly();
-		using StreamReader reader = new StreamReader(assembly.GetManifestResourceStream("DDoor.ArchipelagoRandomizer.Data.Items.json"));
-		itemData = JsonConvert.DeserializeObject<List<Item>>(reader.ReadToEnd());
+        using StreamReader reader = new StreamReader(assembly.GetManifestResourceStream("DDoor.ArchipelagoRandomizer.Data.Items.json"));
+        itemData = JsonConvert.DeserializeObject<List<Item>>(reader.ReadToEnd());
+    }
+    
+    public static string APItemInfoToDDItemName(ItemInfo itemInfo)
+	{
+        if (itemInfo.ItemGame == "Death's Door")
+        {
+            try
+            {
+                return itemData.First(entry => entry.apItemId == itemInfo.ItemId).itemChangerName;
+            }
+            catch (InvalidOperationException)
+            {
+                return $"Unknown Item: {itemInfo.ItemDisplayName}";
+            }
+		}
+        else
+        {
+            return itemInfo.ItemDisplayName;
+        }
 	}
 }

--- a/ArchipelagoRandomizer/Locations.cs
+++ b/ArchipelagoRandomizer/Locations.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using Archipelago.MultiClient.Net.Models;
 using Newtonsoft.Json;
 
 namespace DDoor.ArchipelagoRandomizer;
@@ -19,12 +22,44 @@ public static class Locations
         public readonly string itemChangerName = itemChangerName;
         public readonly long apLocationId = apLocationId;
     }
-    public static List<Location> locationData;
+    private static List<Location> locationData;
 
     private static void PopulateLocationsFromJson()
     {
         Assembly assembly = Assembly.GetExecutingAssembly();
-		using StreamReader reader = new StreamReader(assembly.GetManifestResourceStream("DDoor.ArchipelagoRandomizer.Data.Locations.json"));
-		locationData = JsonConvert.DeserializeObject<List<Location>>(reader.ReadToEnd());
-	}
+        using StreamReader reader = new StreamReader(assembly.GetManifestResourceStream("DDoor.ArchipelagoRandomizer.Data.Locations.json"));
+        locationData = JsonConvert.DeserializeObject<List<Location>>(reader.ReadToEnd());
+    }
+
+    public static string APItemInfoToDDLocationName(ItemInfo itemInfo)
+    {
+        if (itemInfo.ItemGame == "Death's Door")
+        {
+            try
+            {
+                return locationData.First(entry => entry.apLocationId == itemInfo.LocationId).itemChangerName;
+            }
+            catch (InvalidOperationException)
+            {
+                return $"Unknown Location: {itemInfo.LocationDisplayName}";
+            }
+        }
+        else
+        {
+            return itemInfo.LocationDisplayName;
+        }
+    }
+
+    public static long ItemChangerLocationToAPLocationID(string itemChangerLocation)
+    {
+        try
+        {
+            return locationData.First(entry => entry.itemChangerName == itemChangerLocation).apLocationId;
+        }
+        catch (InvalidOperationException)
+        {
+            throw new KeyNotFoundException($"Location with ItemChanger name {itemChangerLocation} was not found. Report this to the developers.");
+        }
+        
+    }
 }


### PR DESCRIPTION
Also make item and location look-ups more resilient in general (and give better errors if unknown items/locations happen).

Items and Locations classes now have look-up helper methods and no longer provide direct access to their data. Tested with all the changes in the previous PRs.