### PR TITLE
Adds the ability to turn on and off Deathlink

### DIFF
--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -3,7 +3,6 @@ using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.Helpers;
 using Archipelago.MultiClient.Net.Models;
 using Archipelago.MultiClient.Net.Packets;
-using DDoor.AddUIToOptionsMenu;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -26,7 +25,7 @@ internal class Archipelago
 	private static readonly string apConfigPath = $"{Application.persistentDataPath}/Archipelago_config.json";
 	private APSaveData apSaveData;
 	internal APConfig apConfig = APConfig.LoadAPConfig();
-	private UIManager uiManager;
+	private UIManager uiManager = UIManager.Instance;
 	private Dictionary<string, object> slotData;
 	private IEnumerator checkItemsReceived;
 	private IEnumerator incomingItemHandler;
@@ -35,6 +34,7 @@ internal class Archipelago
 	private ConcurrentQueue<ItemInfo> outgoingItems;
 	private int itemIndex;
 	private bool isConnected;
+	internal bool IsConnected() => isConnected;
 	private bool hasCompleted;
 	private readonly float itemReceiveDelay = 3f;
 
@@ -60,7 +60,6 @@ internal class Archipelago
 	{
 		Session = ArchipelagoSessionFactory.CreateSession(apSaveData.URL, apSaveData.Port);
 		string message;
-		uiManager = UIManager.Instance;
 
 		LoginResult loginResult = Session.TryConnectAndLogin(
 			"Death's Door",
@@ -381,20 +380,13 @@ internal class Archipelago
 		);
 	}
 
-	internal void AddDeathlinkToggle()
-	{
-		OptionsToggle optionsToggle = new("DEATHLINK", "UI_ToggleDeathlink", "ToggleDeathlink", [IngameUIManager.RelevantScene.TitleScreen], ToggleDeathlink, InitializeDeathlinkToggle);
-		IngameUIManager.AddOptionsToggle(optionsToggle);
-		IngameUIManager.RetriggerModifyingOptionsMenuTitleScreen();
-	}
-
-	private void ToggleDeathlink(bool newValue)
+	internal void ToggleDeathlink(bool newValue)
 	{
 		apConfig.DeathLinkEnabled = newValue;
 		apConfig.SaveAPConfig();
 	}
 
-	private bool InitializeDeathlinkToggle()
+	internal bool InitializeDeathlinkToggle()
 	{
 		return apConfig.DeathLinkEnabled;
 	}

--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -22,10 +22,9 @@ internal class Archipelago
 	public static event Action OnDisconnected;
 	private static readonly Archipelago instance = new();
 	private readonly string apSaveDataPath = $"{Application.persistentDataPath}/SAVEDATA/Save_slot#-Archipelago.json";
-	private static readonly string apConfigPath = $"{Application.persistentDataPath}/Archipelago_config.json";
 	private APSaveData apSaveData;
 	internal APConfig apConfig = APConfig.LoadAPConfig();
-	private UIManager uiManager = UIManager.Instance;
+	private readonly UIManager uiManager = UIManager.Instance;
 	private Dictionary<string, object> slotData;
 	private IEnumerator checkItemsReceived;
 	private IEnumerator incomingItemHandler;
@@ -487,6 +486,7 @@ internal class Archipelago
 
 	public class APConfig
 	{
+		private static readonly string apConfigPath = $"{Application.persistentDataPath}/Archipelago_config.json";
 		public bool DeathLinkEnabled { get; set; } = false;
 
 		internal void SaveAPConfig()

--- a/ArchipelagoRandomizer/DeathManager.cs
+++ b/ArchipelagoRandomizer/DeathManager.cs
@@ -31,7 +31,17 @@ internal class DeathManager : MonoBehaviour
 	private void Awake()
 	{
 		instance = this;
-		deathLinkService = Archipelago.Instance.Session.CreateDeathLinkService();
+		if (Archipelago.Instance.apConfig.DeathLinkEnabled)
+		{
+			deathLinkService = Archipelago.Instance.Session.CreateDeathLinkService();
+			enabled = true;
+			IsDeathLinkEnabled = true;
+		}
+		else
+		{
+			enabled = false;
+			IsDeathLinkEnabled = false;
+		}
 	}
 
 	private void OnEnable()

--- a/ArchipelagoRandomizer/Plugin.cs
+++ b/ArchipelagoRandomizer/Plugin.cs
@@ -9,6 +9,7 @@ namespace DDoor.ArchipelagoRandomizer;
 [BepInDependency("deathsdoor.itemchanger")]
 [BepInDependency("deathsdoor.alternativegamemodes")]
 [BepInDependency("deathsdoor.magicui")]
+[BepInDependency("deathsdoor.adduitooptionsmenu")]
 public class Plugin : BaseUnityPlugin
 {
 	internal static new ManualLogSource Logger;
@@ -32,6 +33,7 @@ public class Plugin : BaseUnityPlugin
 			});
 
 			new Harmony("deathsdoor.archipelagorandomizer").PatchAll();
+			Archipelago.Instance.AddDeathlinkToggle();
 
 			InitStatus = 1;
 		}

--- a/ArchipelagoRandomizer/Plugin.cs
+++ b/ArchipelagoRandomizer/Plugin.cs
@@ -33,7 +33,7 @@ public class Plugin : BaseUnityPlugin
 			});
 
 			new Harmony("deathsdoor.archipelagorandomizer").PatchAll();
-			Archipelago.Instance.AddDeathlinkToggle();
+			UIManager.Instance.AddDeathlinkToggle();
 
 			InitStatus = 1;
 		}

--- a/ArchipelagoRandomizer/UI/CustomUI.cs
+++ b/ArchipelagoRandomizer/UI/CustomUI.cs
@@ -100,6 +100,10 @@ internal abstract class CustomUI
 
 	private Sprite GetBackgroundSprite()
 	{
+		if (backgroundSprites == null)
+		{
+			CacheBackgroundSprite();
+		}
 		if (backgroundSprites.TryGetValue(BackgroundType, out Sprite sprite))
 		{
 			return sprite;

--- a/ArchipelagoRandomizer/UIManager.cs
+++ b/ArchipelagoRandomizer/UIManager.cs
@@ -1,5 +1,6 @@
 ﻿using DDoor.AddUIToOptionsMenu;
 using DDoor.ArchipelagoRandomizer.UI;
+using UnityEngine.SceneManagement;
 
 namespace DDoor.ArchipelagoRandomizer;
 
@@ -8,12 +9,21 @@ internal class UIManager
 	public static readonly UIManager instance = new();
 	private static readonly ConnectionMenu connectionMenu = new();
 	private static readonly NotificationPopup notificationHandler = new();
+	private static bool cachedBackgroundSprite = false;
 
 	public static UIManager Instance => instance;
 
 	private UIManager()
 	{
-		CustomUI.CacheBackgroundSprite();
+		SceneManager.sceneLoaded += OnSceneLoaded;
+	}
+
+	private void OnSceneLoaded(Scene scene, LoadSceneMode _)
+	{
+		if (!cachedBackgroundSprite && scene.name == "TitleScreen")
+		{
+			CustomUI.CacheBackgroundSprite();
+		}
 	}
 
 	public void ShowConnectionMenu()

--- a/ArchipelagoRandomizer/UIManager.cs
+++ b/ArchipelagoRandomizer/UIManager.cs
@@ -1,4 +1,5 @@
-﻿using DDoor.ArchipelagoRandomizer.UI;
+﻿using DDoor.AddUIToOptionsMenu;
+using DDoor.ArchipelagoRandomizer.UI;
 
 namespace DDoor.ArchipelagoRandomizer;
 
@@ -28,5 +29,12 @@ internal class UIManager
 	public void ShowNotification(string message)
 	{
 		notificationHandler.Show(message);
+	}
+
+	internal void AddDeathlinkToggle()
+	{
+		OptionsToggle optionsToggle = new("DEATHLINK", "UI_ToggleDeathlink", "ToggleDeathlink", [IngameUIManager.RelevantScene.TitleScreen], Archipelago.Instance.ToggleDeathlink, Archipelago.Instance.InitializeDeathlinkToggle);
+		IngameUIManager.AddOptionsToggle(optionsToggle);
+		IngameUIManager.RetriggerModifyingOptionsMenuTitleScreen();
 	}
 }

--- a/ArchipelagoRandomizer/UIManager.cs
+++ b/ArchipelagoRandomizer/UIManager.cs
@@ -9,22 +9,10 @@ internal class UIManager
 	public static readonly UIManager instance = new();
 	private static readonly ConnectionMenu connectionMenu = new();
 	private static readonly NotificationPopup notificationHandler = new();
-	private static bool cachedBackgroundSprite = false;
 
 	public static UIManager Instance => instance;
 
-	private UIManager()
-	{
-		SceneManager.sceneLoaded += OnSceneLoaded;
-	}
-
-	private void OnSceneLoaded(Scene scene, LoadSceneMode _)
-	{
-		if (!cachedBackgroundSprite && scene.name == "TitleScreen")
-		{
-			CustomUI.CacheBackgroundSprite();
-		}
-	}
+	private UIManager() { }
 
 	public void ShowConnectionMenu()
 	{

--- a/DDArchipelagoRandomizer.csproj
+++ b/DDArchipelagoRandomizer.csproj
@@ -65,6 +65,10 @@
 			<HintPath>$(PluginsPath)/MagicUI/MagicUI.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="AddUIToOptionsMenu">
+			<HintPath>$(PluginsPath)/AddUIToOptionsMenu/AddUIToOptionsMenu.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ We talk about the development of this in the Death's Door thread in the `future-
 ### Building
 1. Clone this repository.
 1. Install these mods into your Death's Door plugins folder:
-    - [Alternative Game Modes](https://github.com/dpinela/DeathsDoor.AlternativeGameModes)
-    - [Item Changer](https://github.com/dpinela/DeathsDoor.ItemChanger)
+    - [Alternative Game Modes](https://github.com/dpinela/DeathsDoor.AlternativeGameModes) (required)
+    - [Item Changer](https://github.com/dpinela/DeathsDoor.ItemChanger) (required)
+    - [MagicUI](https://github.com/dpinela/DeathsDoor.MagicUI) (required)
+    - [AddUIToOptionsMenu](github.com/roseasromeo/DeathsDoor.AddUIToOptionsMenu) (required)
+    - [ReturnToSpawn](https://github.com/roseasromeo/DeathsDoorReturnToSpawn) (recommended, but not required)
 1. Create a new file at the project's root named `config.targets` and add the following code:
     ```xml
     <?xml version="1.0" encoding="utf-8"?>
@@ -31,7 +34,7 @@ We talk about the development of this in the Death's Door thread in the `future-
     </Project>
     ```
     Replace `Path\To\Your\Death's\Door\Plugins\Directory`.
-    This will usually be at [`Game directory]\BepInEx\plugins`, unless you changed the default location.
+    This will usually be at `Game directory]\BepInEx\plugins`, unless you changed the default location.
 1. Navigate to the project's root directory in a terminal and run `dotnet restore` to install packages.
 1. Build the project.
 
@@ -52,8 +55,8 @@ We talk about the development of this in the Death's Door thread in the `future-
 Thanks to [dpinela](https://github.com/dpinela) for their work on the
 [Multiworld Randomizer](https://github.com/dpinela/DeathsDoor.Randomizer)
 (of which I'm using to figure out how to make this mod) and for the dependencies this mod uses:
-[Alternative Game Modes](https://github.com/dpinela/DeathsDoor.AlternativeGameModes) and
-[Item Changer](https://github.com/dpinela/DeathsDoor.ItemChanger)!
+[Alternative Game Modes](https://github.com/dpinela/DeathsDoor.AlternativeGameModes),
+[Item Changer](https://github.com/dpinela/DeathsDoor.ItemChanger), and [MagicUI](https://github.com/dpinela/DeathsDoor.MagicUI)!
 
 Thanks to [lunix33](https://github.com/lunix33) for starting this project with their work on the
 [APWorld](https://github.com/lunix33/Archipelago_DeathsDoor/tree/deaths-door/worlds/deaths_door) side of things!

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We talk about the development of this in the Death's Door thread in the `future-
     - [Alternative Game Modes](https://github.com/dpinela/DeathsDoor.AlternativeGameModes) (required)
     - [Item Changer](https://github.com/dpinela/DeathsDoor.ItemChanger) (required)
     - [MagicUI](https://github.com/dpinela/DeathsDoor.MagicUI) (required)
-    - [AddUIToOptionsMenu](github.com/roseasromeo/DeathsDoor.AddUIToOptionsMenu) (required)
+    - [AddUIToOptionsMenu](https://github.com/roseasromeo/DeathsDoor.AddUIToOptionsMenu) (required)
     - [ReturnToSpawn](https://github.com/roseasromeo/DeathsDoorReturnToSpawn) (recommended, but not required)
 1. Create a new file at the project's root named `config.targets` and add the following code:
     ```xml


### PR DESCRIPTION
This changes enable the user to turn on and off Deathlink via an option in the Title Screen options menu. Deathlink now defaults to Off.

To facilitate this option, I wrote an additional mod [AddUIToOptionsMenu](https://github.com/roseasromeo/DeathsDoor.AddUIToOptionsMenu) so that other mods can easily add toggles/buttons to the options menu on the Title Screen and in-game. This PR adds a dependency on this mod.

I also added a way to store a configuration file for the AP mod in the AppData folder for Death's Door (next to where the game stores its Config).

I updated the Readme to include the new dependency, the missed MagicUI dependency, and a suggestion of the ReturnToSpawn mod, which will facilitate Entrance Rando eventually.