### PR TITLE
When pressing Start on an AP file, show Connection Menu

### DIFF
--- a/ArchipelagoRandomizer/ArchipelagoRandomizerMod.cs
+++ b/ArchipelagoRandomizer/ArchipelagoRandomizerMod.cs
@@ -74,6 +74,8 @@ internal class ArchipelagoRandomizerMod
 				UIManager.Instance.HideConnectionMenu();
 				SaveMenu saveMenu = TitleScreen.instance.saveMenu;
 				saveMenu.saveSlots[saveMenu.index].LoadSave();
+				GameSave.currentSave.SetKeyState("ArchipelagoRandomizer", true);
+				GameSave.currentSave.Save();
 			}
 		}
 		catch (LoginValidationException ex)

--- a/ArchipelagoRandomizer/ArchipelagoRandomizerMod.cs
+++ b/ArchipelagoRandomizer/ArchipelagoRandomizerMod.cs
@@ -60,13 +60,7 @@ internal class ArchipelagoRandomizerMod
 		ConnectToArchipelago(connectionInfo);
 	}
 
-	public void EnableMod()
-	{
-		APSaveData connectionInfo = Archipelago.Instance.GetAPSaveData();
-		ConnectToArchipelago(connectionInfo, isAlreadyLoading: true);
-	}
-
-	private async void ConnectToArchipelago(APSaveData connectionInfo, bool isAlreadyLoading = false)
+	private async void ConnectToArchipelago(APSaveData connectionInfo)
 	{
 		try
 		{
@@ -77,13 +71,9 @@ internal class ArchipelagoRandomizerMod
 				ItemRandomizer itemRando = archipelagoRandomizer.AddComponent<ItemRandomizer>();
 				archipelagoRandomizer.AddComponent<DeathManager>();
 				Object.DontDestroyOnLoad(archipelagoRandomizer);
-
-				if (!isAlreadyLoading)
-				{
-					UIManager.Instance.HideConnectionMenu();
-					SaveMenu saveMenu = TitleScreen.instance.saveMenu;
-					saveMenu.saveSlots[saveMenu.index].LoadSave();
-				}
+				UIManager.Instance.HideConnectionMenu();
+				SaveMenu saveMenu = TitleScreen.instance.saveMenu;
+				saveMenu.saveSlots[saveMenu.index].LoadSave();
 			}
 		}
 		catch (LoginValidationException ex)
@@ -99,27 +89,5 @@ internal class ArchipelagoRandomizerMod
 	{
 		Object.Destroy(archipelagoRandomizer);
 		Archipelago.Instance.Disconnect();
-	}
-
-	[HarmonyPatch]
-	private class Patches
-	{
-		/// <summary>
-		/// Enables the mod if a compatible save file is loaded
-		/// </summary>
-		[HarmonyPrefix, HarmonyPatch(typeof(SaveSlot), nameof(SaveSlot.useSaveFile))]
-		private static void LoadFilePatch(SaveSlot __instance)
-		{
-			GameSave.currentSave = __instance.saveFile;
-
-			if (__instance.saveFile.IsLoaded() && GameSave.currentSave.IsKeyUnlocked("ArchipelagoRandomizer"))
-			{
-				// If loading AP file
-				if (AGM.AlternativeGameModes.SelectedModeName == "START")
-				{
-					instance.EnableMod();
-				}
-			}
-		}
 	}
 }

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -219,7 +219,7 @@ internal class ConnectionMenu : CustomUI
 		// Wait for end of frame so we can select it after the others have been created
 		yield return new WaitForEndOfFrame();
 		yield return new WaitForEndOfFrame();
-		portInput.SelectAndActivate();
+		urlInput.SelectAndActivate();
 	}
 
 	[HarmonyPatch]

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -177,10 +177,23 @@ internal class ConnectionMenu : CustomUI
 			{
 				ClickedConnect(null);
 			}
-			else if (Input.GetKeyDown(KeyCode.Tab))
+			else if (Input.GetKeyDown(KeyCode.Tab) || Buttons.Tapped("MenuRight"))
 			{
 				currentInputFieldIndex = (currentInputFieldIndex + 1) % tabbableInputs.Length;
 				tabbableInputs[currentInputFieldIndex].SelectAndActivate();
+			}
+			else if (Buttons.Tapped("MenuLeft"))
+			{
+				currentInputFieldIndex = (currentInputFieldIndex - 1) % tabbableInputs.Length;
+				if (currentInputFieldIndex < 0)
+				{
+					currentInputFieldIndex += tabbableInputs.Length;
+				}
+				tabbableInputs[currentInputFieldIndex].SelectAndActivate();
+			}
+			else if (Input.GetKeyDown(KeyCode.Escape) || Buttons.Tapped("MenuBack"))
+			{
+				ClickedBack(null);
 			}
 
 			yield return null;

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -173,7 +173,7 @@ internal class ConnectionMenu : CustomUI
 				yield return null;
 			}
 
-			if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter))
+			if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter) || Buttons.Tapped("MenuOk"))
 			{
 				ClickedConnect(null);
 			}

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -173,8 +173,9 @@ internal class ConnectionMenu : CustomUI
 				yield return null;
 			}
 
-			if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter) || Buttons.Tapped("MenuOk"))
+			if (!Input.GetKey(KeyCode.Space) & (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter) || Buttons.Tapped("MenuOk")))
 			{
+				//Filter out space so that folks can have spaces in Player names
 				ClickedConnect(null);
 			}
 			else if (Input.GetKeyDown(KeyCode.Tab) || Buttons.Tapped("MenuRight"))

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -46,7 +46,7 @@ internal class ConnectionMenu : CustomUI
 		{
 			HorizontalAlignment = HorizontalAlignment.Center,
 			VerticalAlignment = VerticalAlignment.Center,
-			Padding = new Padding(30),
+			Padding = new Padding(60),
 		};
 		TextObject headingText = new TextObject(layoutRoot, "Heading")
 		{

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -232,12 +232,12 @@ internal class ConnectionMenu : CustomUI
 		[HarmonyPrefix, HarmonyPatch(typeof(SaveMenu), nameof(SaveMenu.startGame))]
 		private static bool StartGamePatch(SaveMenu __instance)
 		{
-			if (AGM.AlternativeGameModes.SelectedModeName == "ARCHIPELAGO")
+			GameSave.currentSave = __instance.saveSlots[__instance.index].saveFile;
+			if (AGM.AlternativeGameModes.SelectedModeName == "ARCHIPELAGO" || (AGM.AlternativeGameModes.SelectedModeName == "START" && GameSave.currentSave.IsKeyUnlocked("ArchipelagoRandomizer")))
 			{
 				UIManager.Instance.ShowConnectionMenu();
 				return false;
 			}
-
 			return true;
 		}
 	}


### PR DESCRIPTION
Prior behavior sometimes resulted into loading into game before AP connection happened (and thus ItemChanger fully loading). This change shows the Connection Menu when Start is pressed on a file that has previously been used as an AP file.

Depends on #6 (includes those commits)