### PR TITLE
Make SyncCheckedLocations collect aware

### DIFF
--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -223,15 +223,15 @@ internal class Archipelago
 
 	private void SyncLocationsChecked(APSaveData apSaveData)
 	{
-		int locationsCheckedOnServer = Session.Locations.AllLocationsChecked.Count;
-		int locationsCheckedOnSave = apSaveData.LocationsChecked.Count;
-
-		if (locationsCheckedOnServer < locationsCheckedOnSave)
+		// This resync now accounts for collect/same slot co-op/starting a new file
+		// Some locations may be checked on server and not checked locally
+		// We want to send out any locally checked locations (i.e. if lose connection during play), even if the server has more locations checked than us.
+		foreach (string locationName in apSaveData.LocationsChecked)
 		{
-			for (int i = locationsCheckedOnServer; i < locationsCheckedOnSave; i++)
+			long locationId = Locations.ItemChangerLocationToAPLocationID(locationName);
+			if (!Session.Locations.AllLocationsChecked.Contains(locationId))
 			{
-				string checkedLocation = apSaveData.LocationsChecked[i];
-				SendLocationChecked(checkedLocation);
+				SendLocationChecked(locationName);
 			}
 		}
 	}


### PR DESCRIPTION
Instead of comparing the count of local locations checked to the server's count, look for locations in the local save that aren't in the server's list and send those.

This change will make the resync compatible with collect, same slot co-op, and starting a new save.

Depends on #10 (includes those commits)

Will have a merge conflict with another PR that added a comment that I should come back and fix this problem.