### PR TITLE
Fix Double Item Notification

### DIFF
--- a/ArchipelagoRandomizer/ItemRandomizer.cs
+++ b/ArchipelagoRandomizer/ItemRandomizer.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using System.Linq;
 using UnityEngine;
 using IC = DDoor.ItemChanger;
 
@@ -194,6 +195,46 @@ internal class ItemRandomizer : MonoBehaviour
 		private static void LoadFilePatch()
 		{
 			instance.PlaceItems();
+		}
+
+		/// <summary>
+		/// Hooks ItemChanger's CornerPopup to suppress local item notifications for us
+		/// </summary>
+		[HarmonyPrefix, HarmonyPatch(typeof(IC.CornerPopup), nameof(IC.CornerPopup.Show), [typeof(IC.Item)])]
+		private static bool ShowPatch(IC.Item x)
+		{
+			IC.LoggedItem loggedItem = (IC.LoggedItem)x;
+			if (loggedItem.Item.GetType() == typeof(DDItem))
+			{
+				DDItem dDItem = (DDItem)loggedItem.Item;
+				bool IsForAnotherPlayer = Archipelago.Instance.ScoutedPlacements.First(ip => ip.Location == dDItem.Location).IsForAnotherPlayer;
+				// Logger.LogWarning($"{IsForAnotherPlayer}");
+				return IsForAnotherPlayer; // if for this player, skip the notification
+			}
+			return true;
+		}
+
+		/// <summary>
+		/// Hooks ItemChanger's LoggedItem Trigger to suppress local items being shown in the tracker log for us
+		/// </summary>
+		[HarmonyPrefix, HarmonyPatch(typeof(IC.LoggedItem), nameof(IC.LoggedItem.Trigger))]
+		private static bool TriggerPatch(IC.LoggedItem __instance)
+		{
+			if (__instance.Item.GetType() == typeof(DDItem))
+			{
+				DDItem dDItem = (DDItem)__instance.Item;
+				bool IsForAnotherPlayer = Archipelago.Instance.ScoutedPlacements.First(ip => ip.Location == dDItem.Location).IsForAnotherPlayer;
+				if (IsForAnotherPlayer)
+				{
+					return true;
+				}
+				else // if for this player, skip the notification
+				{
+					dDItem.Trigger();
+					return false;
+				} 
+			}
+			return true;
 		}
 
 	}

--- a/ArchipelagoRandomizer/ItemRandomizer.cs
+++ b/ArchipelagoRandomizer/ItemRandomizer.cs
@@ -33,11 +33,6 @@ internal class ItemRandomizer : MonoBehaviour
 		bool receivedFromSelf = playerSlot == Archipelago.Instance.CurrentPlayer.Slot;
 		Sprite icon;
 		string message;
-		// if (GameSave.currentSave.IsKeyUnlocked($"AP_PickedUp-{location}") & receivedFromSelf)
-		// {
-		// 	Logger.Log($"Already received item at {location} when it was picked up, so don't receive it again");
-		// 	return;
-		// } // The corner popup seems more informative on with the second version, so currently allowing both to trigger
 
 		if (!IC.Predefined.TryGetItem(itemName, out IC.Item item))
 		{

--- a/DDArchipelagoRandomizer.csproj
+++ b/DDArchipelagoRandomizer.csproj
@@ -57,7 +57,7 @@
 			<HintPath>$(PluginsPath)/AlternativeGameModes/AlternativeGameModes.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<Reference Include="ItemChanger">
+		<Reference Include="ItemChanger" Publicize="true">
 			<HintPath>$(PluginsPath)/ItemChanger/ItemChanger.dll</HintPath>
 			<Private>False</Private>
 		</Reference>


### PR DESCRIPTION
This change patches ItemChanger to change its behavior if a found item is from our mod and for this player. Both the CornerPopup and the addition to the RecentItemsDisplay are suppressed, in favor of showing the better notification on item receipt from the server.

If checking already checked locations that had local items (i.e. by starting a new file for the same room or during same slot co-op), this change results in no notification for the player that they've picked up an item; however, hopefully the player is aware that they are checking repeat locations. Having a good map tracker will help players with this part.

Depends on #9 (includes that commit)