### PR TITLE
Change Port Field to be numeric and only accept up to 5 characters

### DIFF
--- a/ArchipelagoRandomizer/Plugin.cs
+++ b/ArchipelagoRandomizer/Plugin.cs
@@ -1,8 +1,6 @@
 ﻿using BepInEx;
 using BepInEx.Logging;
 using HarmonyLib;
-using System;
-using System.Collections.Generic;
 using UnityEngine.Events;
 using AGM = DDoor.AlternativeGameModes;
 
@@ -19,7 +17,9 @@ public class Plugin : BaseUnityPlugin
 
 	public static Plugin Instance => instance;
 	public int InitStatus { get; internal set; } = 0;
-	internal UnityAction onUpdate;
+
+	#nullable enable
+	internal event UnityAction? OnUpdate;
 
 	private void Awake()
 	{
@@ -48,6 +48,8 @@ public class Plugin : BaseUnityPlugin
 
 	private void Update()
 	{
-		onUpdate.Invoke();
+		OnUpdate?.Invoke();
 	}
 }
+
+#nullable disable

--- a/ArchipelagoRandomizer/Plugin.cs
+++ b/ArchipelagoRandomizer/Plugin.cs
@@ -1,6 +1,9 @@
 ﻿using BepInEx;
 using BepInEx.Logging;
 using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using UnityEngine.Events;
 using AGM = DDoor.AlternativeGameModes;
 
 namespace DDoor.ArchipelagoRandomizer;
@@ -16,6 +19,7 @@ public class Plugin : BaseUnityPlugin
 
 	public static Plugin Instance => instance;
 	public int InitStatus { get; internal set; } = 0;
+	internal UnityAction onUpdate;
 
 	private void Awake()
 	{
@@ -40,5 +44,10 @@ public class Plugin : BaseUnityPlugin
 			InitStatus = 2;
 			throw err;
 		}
+	}
+
+	private void Update()
+	{
+		onUpdate.Invoke();
 	}
 }

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -219,7 +219,7 @@ internal class ConnectionMenu : CustomUI
 		// Wait for end of frame so we can select it after the others have been created
 		yield return new WaitForEndOfFrame();
 		yield return new WaitForEndOfFrame();
-		portInput.SelectAndActivate();
+		urlInput.SelectAndActivate();
 	}
 
 	[HarmonyPatch]

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -177,10 +177,23 @@ internal class ConnectionMenu : CustomUI
 			{
 				ClickedConnect(null);
 			}
-			else if (Input.GetKeyDown(KeyCode.Tab))
+			else if (Input.GetKeyDown(KeyCode.Tab) || Buttons.Tapped("MenuRight"))
 			{
 				currentInputFieldIndex = (currentInputFieldIndex + 1) % tabbableInputs.Length;
 				tabbableInputs[currentInputFieldIndex].SelectAndActivate();
+			}
+			else if (Buttons.Tapped("MenuLeft"))
+			{
+				currentInputFieldIndex = (currentInputFieldIndex - 1) % tabbableInputs.Length;
+				if (currentInputFieldIndex < 0)
+				{
+					currentInputFieldIndex += tabbableInputs.Length;
+				}
+				tabbableInputs[currentInputFieldIndex].SelectAndActivate();
+			}
+			else if (Input.GetKeyDown(KeyCode.Escape) || Buttons.Tapped("MenuBack"))
+			{
+				ClickedBack(null);
 			}
 
 			yield return null;

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -173,7 +173,7 @@ internal class ConnectionMenu : CustomUI
 				yield return null;
 			}
 
-			if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter))
+			if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter) || Buttons.Tapped("MenuOk"))
 			{
 				ClickedConnect(null);
 			}

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -173,8 +173,9 @@ internal class ConnectionMenu : CustomUI
 				yield return null;
 			}
 
-			if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter) || Buttons.Tapped("MenuOk"))
+			if (!Input.GetKey(KeyCode.Space) & (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter) || Buttons.Tapped("MenuOk")))
 			{
+				//Filter out space so that folks can have spaces in Player names
 				ClickedConnect(null);
 			}
 			else if (Input.GetKeyDown(KeyCode.Tab) || Buttons.Tapped("MenuRight"))

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -46,7 +46,7 @@ internal class ConnectionMenu : CustomUI
 		{
 			HorizontalAlignment = HorizontalAlignment.Center,
 			VerticalAlignment = VerticalAlignment.Center,
-			Padding = new Padding(30),
+			Padding = new Padding(60),
 		};
 		TextObject headingText = new TextObject(layoutRoot, "Heading")
 		{

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -28,7 +28,7 @@ internal class ConnectionMenu : CustomUI
 		base.Show();
 		Prefill();
 		Plugin.Instance.StartCoroutine(SelectFirstTextInput());
-		Plugin.Instance.onUpdate += CheckForInputs;
+		Plugin.Instance.OnUpdate += CheckForInputs;
 	}
 
 	public override void Hide()

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -34,7 +34,7 @@ internal class ConnectionMenu : CustomUI
 	public override void Hide()
 	{
 		base.Hide();
-		Plugin.Instance.onUpdate -= CheckForInputs;
+		Plugin.Instance.OnUpdate -= CheckForInputs;
 	}
 
 	protected override void Create()

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -24,7 +24,7 @@ internal class ConnectionMenu : CustomUI
 
 	public override void Show()
 	{
-		currentInputFieldIndex = 1;
+		currentInputFieldIndex = 0;
 		base.Show();
 		Prefill();
 		Plugin.Instance.StartCoroutine(SelectFirstTextInput());

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -4,6 +4,7 @@ using MagicUI.Elements;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UEUI = UnityEngine.UI;
 using AGM = DDoor.AlternativeGameModes;
 
 namespace DDoor.ArchipelagoRandomizer.UI;
@@ -58,7 +59,8 @@ internal class ConnectionMenu : CustomUI
 		};
 		mainStack.Children.Add(headingText);
 		urlInput = CreateTextInput("URLInput", 400, "URL (eg. archipelago.gg)");
-		portInput = CreateTextInput("PortInput", 200, "Port (eg. 38281)");
+		portInput = CreateNumericalInput("PortInput", 200, "Port (eg. 38281)");
+		portInput.GameObject.GetComponent<UEUI.InputField>().characterLimit = 5; // Ports are max 5 numbers
 		mainStack.Children.Add(CreateStackLayout("URLPortStack", urlInput, portInput));
 		slotNameInput = CreateTextInput("SlotNameInput", 200, "Player name");
 		passwordInput = CreateTextInput("PasswordInput", 400, "Password");
@@ -150,6 +152,18 @@ internal class ConnectionMenu : CustomUI
 			FontSize = 50,
 			Placeholder = placeholder,
 			Padding = new Padding(25)
+		};
+	}
+
+	private TextInput CreateNumericalInput(string name, int minWidth, string placeholder)
+	{
+		return new TextInput(layoutRoot, name)
+		{
+			MinWidth = minWidth,
+			FontSize = 50,
+			Placeholder = placeholder,
+			Padding = new Padding(25),
+			ContentType = UEUI.InputField.ContentType.IntegerNumber
 		};
 	}
 

--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -86,7 +86,14 @@ internal class ConnectionMenu : CustomUI
 		}
 
 		urlInput.Text = connectioninfo.URL;
-		portInput.Text = connectioninfo.Port.ToString();
+		if (connectioninfo.Port == 0)
+		{
+			portInput.Text = "";
+		}
+		else
+		{
+			portInput.Text = connectioninfo.Port.ToString();
+		}
 		slotNameInput.Text = connectioninfo.SlotName;
 		passwordInput.Text = connectioninfo.Password;
 	}


### PR DESCRIPTION
Ports are limited to be max 5 digit integers, so change the input field settings to reflect that (it won't let you type letters in there). Also, if the port has not yet been set, a 0 would be populated blocking the help text, so now 0 (an invalid port number) is replaced by an empty string during Prefill.

Depends on #6 