### PR TITLE
Optionally Queue Item Notifications instead of Items

### DIFF
--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -320,7 +320,7 @@ internal class Archipelago
 	private bool CanPlayerReceiveItems()
 	{
 		return (
-			// !hasCompleted && AP games can continue after goal
+			// !hasCompleted && // AP games can continue after goal
 			PlayerGlobal.instance != null &&
 			!PlayerGlobal.instance.InputPaused() &&
 			PlayerGlobal.instance.IsAlive()

--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -5,7 +5,6 @@ using Archipelago.MultiClient.Net.Models;
 using Archipelago.MultiClient.Net.Packets;
 using HarmonyLib;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
@@ -214,6 +213,7 @@ internal class Archipelago
 		outgoingItemHandler = null;
 		incomingItems = new ConcurrentQueue<(ItemInfo item, int index)>();
 		outgoingItems = new ConcurrentQueue<ItemInfo>();
+		ItemRandomizer.Instance.itemNotifications = new ConcurrentQueue<ItemRandomizer.ItemNotification>();
 
 		Session.Socket.SocketClosed -= OnSocketClosed;
 		Session = null;
@@ -269,6 +269,15 @@ internal class Archipelago
 			{
 				yield return true;
 				continue;
+			}
+
+			if (!apConfig.ReceiveItemsFast)
+			{
+				float timePreDelay = Time.time;
+				while (Time.time - timePreDelay < (incomingItems.Count < 5 ? ItemRandomizer.Instance.itemNotificationDelay : 1))
+				{
+					yield return null;
+				}
 			}
 
 			ItemInfo item = pendingItem.item;

--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -45,7 +45,6 @@ internal class Archipelago
 	private bool isConnected;
 	internal bool IsConnected() => isConnected;
 	private bool hasCompleted;
-	private readonly float itemReceiveDelay = 3f;
 
 	public static Archipelago Instance => instance;
 	public ArchipelagoSession Session { get; private set; }
@@ -128,6 +127,7 @@ internal class Archipelago
 		{
 			incomingItemHandler?.MoveNext();
 			outgoingItemHandler?.MoveNext();
+			ItemRandomizer.Instance.itemNotificationHandler?.MoveNext();
 		}
 	}
 
@@ -269,13 +269,6 @@ internal class Archipelago
 			{
 				yield return true;
 				continue;
-			}
-
-			// Add delay between each item received so player has time to read the notifications
-			float delay = Time.time;
-			while (Time.time - delay < (incomingItems.Count < 5 ? itemReceiveDelay : 1))
-			{
-				yield return null;
 			}
 
 			ItemInfo item = pendingItem.item;

--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -338,6 +338,17 @@ internal class Archipelago
 		return apConfig.DeathLinkEnabled;
 	}
 
+	internal void ToggleItemHandling(bool newValue)
+	{
+		apConfig.ReceiveItemsFast = newValue;
+		apConfig.SaveAPConfig();
+	}
+
+	internal bool InitializeItemHandling()
+	{
+		return apConfig.ReceiveItemsFast;
+	}
+
 	private static string GetAPSaveDataPath(int saveIndex) => $"{Application.persistentDataPath}/SAVEDATA/Save_slot{saveIndex}-Archipelago.json";
 
 	private int GetSaveIndex()
@@ -366,7 +377,7 @@ internal class Archipelago
 		public int Port { get; set; }
 		public string SlotName { get; set; } = "";
 		public string Password { get; set; } = "";
-    public int SaveSlotIndex { get; set; }
+    	public int SaveSlotIndex { get; set; }
 		public string Seed { get; set; } = "";
 		public List<string> LocationsChecked { get; } = [];
 
@@ -419,6 +430,7 @@ internal class Archipelago
 	{
 		private static readonly string apConfigPath = $"{Application.persistentDataPath}/Archipelago_config.json";
 		public bool DeathLinkEnabled { get; set; } = false;
+		public bool ReceiveItemsFast { get; set; } = false;
 
 		internal void SaveAPConfig()
 		{

--- a/ArchipelagoRandomizer/ItemRandomizer.cs
+++ b/ArchipelagoRandomizer/ItemRandomizer.cs
@@ -1,7 +1,6 @@
 ﻿using HarmonyLib;
 using System.Collections;
 using System.Collections.Concurrent;
-using System.Linq;
 using UnityEngine;
 using IC = DDoor.ItemChanger;
 
@@ -15,8 +14,8 @@ internal class ItemRandomizer : MonoBehaviour
 	public static ItemRandomizer Instance => instance;
 
 	internal IEnumerator itemNotificationHandler;
-	private ConcurrentQueue<ItemNotification> itemNotifications;
-	private readonly float itemNotificationDelay = 3f;
+	internal ConcurrentQueue<ItemNotification> itemNotifications;
+	internal readonly float itemNotificationDelay = 3f;
 
 	private void Awake()
 	{
@@ -69,11 +68,14 @@ internal class ItemRandomizer : MonoBehaviour
 				yield return true;
 				continue;
 			}
-			// Add delay between each item notification received so player has time to read the notifications
-			float timePreDelay = Time.time;
-			while (Time.time - timePreDelay < (itemNotifications.Count < 5 ? itemNotificationDelay : 1))
+			// Add delay between each item notification received so player has time to read the notifications (only needed if Fast Items is on)
+			if (Archipelago.Instance.apConfig.ReceiveItemsFast)
 			{
-				yield return null;
+				float timePreDelay = Time.time;
+				while (Time.time - timePreDelay < (itemNotifications.Count < 5 ? itemNotificationDelay : 1))
+				{
+					yield return null;
+				}
 			}
 			int playerSlot = itemNotification.PlayerSlot;
 			IC.Item item = itemNotification.Item;
@@ -103,7 +105,6 @@ internal class ItemRandomizer : MonoBehaviour
 			itemNotifications.TryDequeue(out _);
 		}
 	}
-
 
 
 	private void PickedUpItem(DDItem item)
@@ -210,7 +211,6 @@ internal class ItemRandomizer : MonoBehaviour
 		internal int PlayerSlot = playerSlot;
 		internal IC.Item Item = item;
 	}
-	
 
 	[HarmonyPatch]
 	private class Patches
@@ -270,7 +270,7 @@ internal class ItemRandomizer : MonoBehaviour
 				{
 					dDItem.Trigger();
 					return false;
-				} 
+				}
 			}
 			return true;
 		}

--- a/ArchipelagoRandomizer/Plugin.cs
+++ b/ArchipelagoRandomizer/Plugin.cs
@@ -37,7 +37,7 @@ public class Plugin : BaseUnityPlugin
 			});
 
 			new Harmony("deathsdoor.archipelagorandomizer").PatchAll();
-			UIManager.Instance.AddDeathlinkToggle();
+			UIManager.Instance.AddOptionsMenuItems();
 
 			InitStatus = 1;
 		}

--- a/ArchipelagoRandomizer/UIManager.cs
+++ b/ArchipelagoRandomizer/UIManager.cs
@@ -29,7 +29,13 @@ internal class UIManager
 		notificationHandler.Show(message);
 	}
 
-	internal void AddDeathlinkToggle()
+	internal void AddOptionsMenuItems()
+	{
+		AddDeathlinkToggle();
+		IngameUIManager.RetriggerModifyingOptionsMenuTitleScreen();
+	}
+
+	private void AddDeathlinkToggle()
 	{
 		OptionsToggle optionsToggle = new(itemText: "DEATHLINK", gameObjectName: "ARCHIPELAGO_UI_ToggleDeathlink", id: "ToggleDeathlink", relevantScenes: [IngameUIManager.RelevantScene.TitleScreen], toggleAction: Archipelago.Instance.ToggleDeathlink, toggleValueInitializer: Archipelago.Instance.InitializeDeathlinkToggle, contextText: "BUTTON:CONFIRM Toggle Deathlink BUTTON:BACK Back");
 		IngameUIManager.AddOptionsMenuItem(optionsToggle);

--- a/ArchipelagoRandomizer/UIManager.cs
+++ b/ArchipelagoRandomizer/UIManager.cs
@@ -32,12 +32,19 @@ internal class UIManager
 	internal void AddOptionsMenuItems()
 	{
 		AddDeathlinkToggle();
+		AddItemHandlingToggle();
 		IngameUIManager.RetriggerModifyingOptionsMenuTitleScreen();
 	}
 
 	private void AddDeathlinkToggle()
 	{
 		OptionsToggle optionsToggle = new(itemText: "DEATHLINK", gameObjectName: "ARCHIPELAGO_UI_ToggleDeathlink", id: "ToggleDeathlink", relevantScenes: [IngameUIManager.RelevantScene.TitleScreen], toggleAction: Archipelago.Instance.ToggleDeathlink, toggleValueInitializer: Archipelago.Instance.InitializeDeathlinkToggle, contextText: "BUTTON:CONFIRM Toggle Deathlink BUTTON:BACK Back");
+		IngameUIManager.AddOptionsMenuItem(optionsToggle);
+	}
+
+	private void AddItemHandlingToggle()
+	{
+		OptionsToggle optionsToggle = new(itemText: "RECEIVE ITEMS AS FAST AS POSSIBLE", gameObjectName: "ARCHIPELAGO_UI_ToggleItemHandling", id: "ToggleItemHandling", relevantScenes: [IngameUIManager.RelevantScene.TitleScreen], toggleAction: Archipelago.Instance.ToggleItemHandling, toggleValueInitializer: Archipelago.Instance.InitializeItemHandling, contextText: "BUTTON:CONFIRM Toggle Fast Items BUTTON:BACK Back");
 		IngameUIManager.AddOptionsMenuItem(optionsToggle);
 	}
 }

--- a/ArchipelagoRandomizer/UIManager.cs
+++ b/ArchipelagoRandomizer/UIManager.cs
@@ -44,7 +44,7 @@ internal class UIManager
 
 	private void AddItemHandlingToggle()
 	{
-		OptionsToggle optionsToggle = new(itemText: "RECEIVE ITEMS AS FAST AS POSSIBLE", gameObjectName: "ARCHIPELAGO_UI_ToggleItemHandling", id: "ToggleItemHandling", relevantScenes: [IngameUIManager.RelevantScene.TitleScreen], toggleAction: Archipelago.Instance.ToggleItemHandling, toggleValueInitializer: Archipelago.Instance.InitializeItemHandling, contextText: "BUTTON:CONFIRM Toggle Fast Items BUTTON:BACK Back");
+		OptionsToggle optionsToggle = new(itemText: "RECEIVE ITEMS AS FAST AS POSSIBLE", gameObjectName: "ARCHIPELAGO_UI_ToggleItemHandling", id: "ToggleItemHandling", relevantScenes: [IngameUIManager.RelevantScene.TitleScreen, IngameUIManager.RelevantScene.InGame], toggleAction: Archipelago.Instance.ToggleItemHandling, toggleValueInitializer: Archipelago.Instance.InitializeItemHandling, contextText: "BUTTON:CONFIRM Toggle Fast Items BUTTON:BACK Back");
 		IngameUIManager.AddOptionsMenuItem(optionsToggle);
 	}
 }

--- a/ArchipelagoRandomizer/UIManager.cs
+++ b/ArchipelagoRandomizer/UIManager.cs
@@ -44,7 +44,7 @@ internal class UIManager
 
 	private void AddItemHandlingToggle()
 	{
-		OptionsToggle optionsToggle = new(itemText: "RECEIVE ITEMS AS FAST AS POSSIBLE", gameObjectName: "ARCHIPELAGO_UI_ToggleItemHandling", id: "ToggleItemHandling", relevantScenes: [IngameUIManager.RelevantScene.TitleScreen, IngameUIManager.RelevantScene.InGame], toggleAction: Archipelago.Instance.ToggleItemHandling, toggleValueInitializer: Archipelago.Instance.InitializeItemHandling, contextText: "BUTTON:CONFIRM Toggle Fast Items BUTTON:BACK Back");
+		OptionsToggle optionsToggle = new(itemText: "FAST ITEMS", gameObjectName: "ARCHIPELAGO_UI_ToggleItemHandling", id: "ToggleItemHandling", relevantScenes: [IngameUIManager.RelevantScene.TitleScreen, IngameUIManager.RelevantScene.InGame], toggleAction: Archipelago.Instance.ToggleItemHandling, toggleValueInitializer: Archipelago.Instance.InitializeItemHandling, contextText: "BUTTON:CONFIRM Toggle Fast Items BUTTON:BACK Back");
 		IngameUIManager.AddOptionsMenuItem(optionsToggle);
 	}
 }


### PR DESCRIPTION
Adds a new Fast Items Toggle to the Title Screen and In-game so that the items can optionally be received as fast as the server, Multiclient, and the game processing can receive them, and queue the notifications instead. This option is particularly useful during a release (so that the player can start playing right away), but folks who want to experience the items as they get notifications or are sensitive to flashing (particularly from the doors) may want to keep this option off.