### PR TITLE
Move adding the item changer icons to before first IC load

### DIFF
--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -194,6 +194,7 @@ internal class Archipelago
 		}
 
 		//Load the ItemChanger SaveData early so that we can peek and see if we need to scout
+		IC.ItemIcons.AddPath(Path.GetDirectoryName(typeof(Plugin).Assembly.Location) + "/Resources/Item Changer Icons");
 		IC.SaveData.Load("slot" + apSaveData.SaveSlotIndex.ToString());
 		IC.SaveData icSaveData = IC.SaveData.Open();
 		if (icSaveData.UnnamedPlacements.Count == 0)

--- a/ArchipelagoRandomizer/ItemRandomizer.cs
+++ b/ArchipelagoRandomizer/ItemRandomizer.cs
@@ -20,7 +20,6 @@ internal class ItemRandomizer : MonoBehaviour
 	private void Awake()
 	{
 		instance = this;
-		IC.ItemIcons.AddPath(System.IO.Path.GetDirectoryName(typeof(Plugin).Assembly.Location) + "/Resources/Item Changer Icons");
 		itemNotifications = new ConcurrentQueue<ItemNotification>();
 		itemNotificationHandler = ItemNotificationHandler();
 	}


### PR DESCRIPTION
Fixes error caught on first load resulting from not being able to find the AP icon