### PR TITLE
Implement life seed yaml option from slot data

### DIFF
--- a/ArchipelagoRandomizer/ItemRandomizer.cs
+++ b/ArchipelagoRandomizer/ItemRandomizer.cs
@@ -151,7 +151,7 @@ internal class ItemRandomizer : MonoBehaviour
 		}
 
 		// Determine starting weapon
-		long startWeapon = Archipelago.Instance.GetSlotData<long>("start_weapon"); // TODO: handle this with starting inventory?
+		long startWeapon = Archipelago.Instance.GetSlotData<long>("start_weapon");
 		string startingWeaponId = startWeapon switch
 		{
 			1 => "daggers",
@@ -161,6 +161,14 @@ internal class ItemRandomizer : MonoBehaviour
 			_ => "sword"
 		};
 		icSaveData.StartingWeapon = startingWeaponId;
+
+		// Life seed required count
+		long lifeSeedCount = Archipelago.Instance.GetSlotData<long>("plant_pot_number");
+		if (lifeSeedCount == 0)
+		{
+			lifeSeedCount = 50; // 0 is not a possible yaml option, so the slot data must be missing the number. Original default was 50.
+		}
+		icSaveData.GreenTabletDoorCost = (int)lifeSeedCount;
 
 		GameSave saveFile = TitleScreen.instance.saveMenu.saveSlots[TitleScreen.instance.saveMenu.index].saveFile;
 		saveFile.weaponId = icSaveData.StartingWeapon;


### PR DESCRIPTION
In preparation for adding the option on the apworld side. Modifies the number of life seeds required for the Green Tablet door using ItemChanger's mechanism for doing so.

Has back compatibility built in for generations prior to the yaml option being added.