### PR TITLE
Implement soul multiplier option from slot data

### DIFF
--- a/ArchipelagoRandomizer/ItemRandomizer.cs
+++ b/ArchipelagoRandomizer/ItemRandomizer.cs
@@ -227,6 +227,21 @@ internal class ItemRandomizer : MonoBehaviour
 			}
 		}
 
+		[HarmonyPrefix, HarmonyPatch(typeof(Inventory), nameof(Inventory.GainSoul))]
+		private static void CurrencyMultiplierPatch1(ref int count)
+		{
+			count *= (int)Archipelago.Instance.GetSlotData<long>("soul_multiplier");
+		}
+
+		[HarmonyPrefix, HarmonyPatch(typeof(Inventory), nameof(Inventory.AddItem), [typeof(InventoryItem), typeof(int)])]
+		private static void CurrencyMultiplierPatch2(InventoryItem i, ref int quantity)
+		{
+			if (i.id == "currency")
+			{
+				quantity *= (int)Archipelago.Instance.GetSlotData<long>("soul_multiplier");
+			}
+		}
+
 		[HarmonyPrefix, HarmonyPatch(typeof(SaveSlot), nameof(SaveSlot.LoadSave))]
 		[HarmonyAfter("deathsdoor.itemchanger")] // Needs to go after ItemChanger has loaded its save
 		private static void LoadFilePatch()

--- a/ArchipelagoRandomizer/ItemRandomizer.cs
+++ b/ArchipelagoRandomizer/ItemRandomizer.cs
@@ -26,8 +26,7 @@ internal class ItemRandomizer : MonoBehaviour
 			if (!soulMultiplier.HasValue)
 			{
 				// Ensure multiplier never goes below 1
-				//soulMultiplier = Mathf.Max(1, (int)Archipelago.Instance.GetSlotData<long>("soul_multiplier"));
-				soulMultiplier = 10;
+				soulMultiplier = Mathf.Max(1, (int)Archipelago.Instance.GetSlotData<long>("soul_multiplier"));
 			}
 
 			return soulMultiplier.Value;

--- a/ArchipelagoRandomizer/ItemRandomizer.cs
+++ b/ArchipelagoRandomizer/ItemRandomizer.cs
@@ -26,7 +26,8 @@ internal class ItemRandomizer : MonoBehaviour
 			if (!soulMultiplier.HasValue)
 			{
 				// Ensure multiplier never goes below 1
-				soulMultiplier = Mathf.Max(1, (int)Archipelago.Instance.GetSlotData<long>("soul_multiplier"));
+				//soulMultiplier = Mathf.Max(1, (int)Archipelago.Instance.GetSlotData<long>("soul_multiplier"));
+				soulMultiplier = 10;
 			}
 
 			return soulMultiplier.Value;
@@ -65,8 +66,9 @@ internal class ItemRandomizer : MonoBehaviour
 			return;
 		}
 
-		Logger.Log($"Received {itemName} from {playerName}");
-		itemNotifications.Enqueue(new ItemNotification(itemName, location, playerSlot, item));
+		string modifiedItemName = ModifyItemName(itemName);
+		Logger.Log($"Received {modifiedItemName} from {playerName}");
+		itemNotifications.Enqueue(new ItemNotification(modifiedItemName, location, playerSlot, item));
 
 		GameSave.currentSave.IncreaseCountKey("AP_ItemsReceived");
 		item?.Trigger();
@@ -100,7 +102,7 @@ internal class ItemRandomizer : MonoBehaviour
 			bool receivedFromSelf = playerSlot == Archipelago.Instance.CurrentPlayer.Slot;
 			string playerName = Archipelago.Instance.Session.Players.GetPlayerName(playerSlot);
 			Sprite icon = IC.ItemIcons.Get(item.Icon);
-			string message = $"You got {item.DisplayName}";
+			string message = $"You got {itemName}";
 
 			if (!receivedFromSelf)
 			{
@@ -113,7 +115,7 @@ internal class ItemRandomizer : MonoBehaviour
 			{
 				LocationName = location,
 				ItemName = itemName,
-				ItemDisplayName = receivedFromSelf ? item.DisplayName : item.DisplayName + $" from {playerName}",
+				ItemDisplayName = receivedFromSelf ? itemName : itemName + $" from {playerName}",
 				ItemIcon = item.Icon
 			};
 			icSaveData.AddToTrackerLog(logEntry);
@@ -188,6 +190,19 @@ internal class ItemRandomizer : MonoBehaviour
 
 		// Save, since ItemChanger doesn't do it for us due to when we run this method
 		saveFile.Save();
+	}
+
+	private string ModifyItemName(string itemName)
+	{
+		switch (itemName)
+		{
+			case "100 Souls":
+				int amount = int.Parse(itemName.Split(' ')[0]) * SoulMultiplier;
+				return $"{amount} Souls";
+		}
+
+		// Nothing to modify
+		return itemName;
 	}
 
 	public struct ItemPlacement(string item, string location, string forPlayer, bool isForAnotherPlayer)


### PR DESCRIPTION
This is in preparation for the APWorld getting this option. Adds a multiplier to all soul gain to make buying upgrades easier.
Confirmed to work for soul orbs, enemy drops, and boss souls