### PR TITLE
Add starting_souls option

### DIFF
--- a/ArchipelagoRandomizer/ItemRandomizer.cs
+++ b/ArchipelagoRandomizer/ItemRandomizer.cs
@@ -161,14 +161,6 @@ internal class ItemRandomizer : MonoBehaviour
 		};
 		icSaveData.StartingWeapon = startingWeaponId;
 
-		// Life seed required count
-		long lifeSeedCount = Archipelago.Instance.GetSlotData<long>("plant_pot_number");
-		if (lifeSeedCount == 0)
-		{
-			lifeSeedCount = 50; // 0 is not a possible yaml option, so the slot data must be missing the number. Original default was 50.
-		}
-		icSaveData.GreenTabletDoorCost = (int)lifeSeedCount;
-
 		GameSave saveFile = TitleScreen.instance.saveMenu.saveSlots[TitleScreen.instance.saveMenu.index].saveFile;
 		saveFile.weaponId = icSaveData.StartingWeapon;
 
@@ -179,6 +171,14 @@ internal class ItemRandomizer : MonoBehaviour
 			LightNight.nightTime = true;
 			saveFile.SetNightState(true);
 		}
+
+		// Life seed required count
+		long lifeSeedCount = Archipelago.Instance.GetSlotData<long>("plant_pot_number");
+		if (lifeSeedCount == 0)
+		{
+			lifeSeedCount = 50; // 0 is not a possible yaml option, so the slot data must be missing the number. Original default was 50.
+		}
+		icSaveData.GreenTabletDoorCost = (int)lifeSeedCount;
 
 		// Set starting souls
 		int startingSouls = (int)Archipelago.Instance.GetSlotData<long>("starting_souls");

--- a/ArchipelagoRandomizer/ItemRandomizer.cs
+++ b/ArchipelagoRandomizer/ItemRandomizer.cs
@@ -163,11 +163,20 @@ internal class ItemRandomizer : MonoBehaviour
 
 		GameSave saveFile = TitleScreen.instance.saveMenu.saveSlots[TitleScreen.instance.saveMenu.index].saveFile;
 		saveFile.weaponId = icSaveData.StartingWeapon;
+
+		// Day or night setting
 		if (Archipelago.Instance.GetSlotData<long>("start_day_or_night") == 1)
 		{
 			Logger.Log("Should be Night, but now on the save file");
 			LightNight.nightTime = true;
 			saveFile.SetNightState(true);
+		}
+
+		// Set starting souls
+		int startingSouls = (int)Archipelago.Instance.GetSlotData<long>("starting_souls");
+		if (startingSouls > 0)
+		{
+			saveFile.SetCountKey("currency", startingSouls);
 		}
 
 		// Save, since ItemChanger doesn't do it for us due to when we run this method


### PR DESCRIPTION
Adds the ability to start with souls based on a yaml option in the apworld.

Added a newGame bool to ItemRandomizer so that we can keep track of if a file is new or a reload (since the souls key set needs to be post file load). May be useful for other post load file modifications in the future.