### PR TITLE
Add pink tablet item to Items.json

### DIFF
--- a/ArchipelagoRandomizer/Data/Items.json
+++ b/ArchipelagoRandomizer/Data/Items.json
@@ -184,6 +184,10 @@
         "itemChangerName": "Purple Ancient Tablet of Knowledge"
     },
     {
+        "apItemId": 806,
+        "itemChangerName": "Pink Ancient Tablet of Knowledge"
+    },
+    {
         "apItemId": 900,
         "itemChangerName": "Lever-Bomb Exit"
     },


### PR DESCRIPTION
I forgot the Pink Ancient Tablet in the first apworld, so it wasn't present in our id to ItemChanger name conversion.

True ending is now technically possibly, although doing it can mess up the player's ability to access Grey Crow and thus goal under current goal conditions.