### PR TITLE
Add notification of update to the mod available

### DIFF
--- a/ArchipelagoRandomizer/Plugin.cs
+++ b/ArchipelagoRandomizer/Plugin.cs
@@ -38,6 +38,7 @@ public class Plugin : BaseUnityPlugin
 
 			new Harmony("deathsdoor.archipelagorandomizer").PatchAll();
 			UIManager.Instance.AddOptionsMenuItems();
+			UIManager.Instance.CheckPluginVersion();
 
 			InitStatus = 1;
 		}

--- a/ArchipelagoRandomizer/UI/CustomUI.cs
+++ b/ArchipelagoRandomizer/UI/CustomUI.cs
@@ -1,4 +1,5 @@
-﻿using MagicUI.Core;
+﻿using DDoor.AddUIToOptionsMenu;
+using MagicUI.Core;
 using MagicUI.Elements;
 using System.Collections;
 using System.Collections.Generic;
@@ -36,8 +37,8 @@ internal abstract class CustomUI
 
 	public static void CacheBackgroundSprite()
 	{
-		Sprite borderSprite = TitleScreen.instance.saveMenu.saveSlots[0].borders[0].sprite;
-		Sprite blurSprite = TitleScreen.instance.keybindMenu.gamepadSubMenu.transform.Find("__Col_Action/KEYBIND_").GetComponent<UnityEngine.UI.Image>().sprite;
+		Sprite borderSprite = PathUtil.GetByPath("TitleScreen", "UI_PauseCanvas/BGMask/SaveMenu/ItemWindow_9slice/ItemWindow/SaveGameSlot/").GetComponent<UnityEngine.UI.Image>().sprite;
+		Sprite blurSprite = PathUtil.GetByPath("TitleScreen", "UI_PauseCanvas/BGMask/OptionsPanels/MENU_KeyBindings_NEW/MENU_Keyboard").transform.Find("__Col_Action/KEYBIND_").GetComponent<UnityEngine.UI.Image>().sprite;
 
 		backgroundSprites = new Dictionary<BackgroundSpriteType, Sprite>()
 		{

--- a/ArchipelagoRandomizer/UIManager.cs
+++ b/ArchipelagoRandomizer/UIManager.cs
@@ -1,16 +1,22 @@
 ﻿using DDoor.AddUIToOptionsMenu;
 using DDoor.ArchipelagoRandomizer.UI;
-using UnityEngine.SceneManagement;
+using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+using System.Net;
+using UnityEngine;
 
 namespace DDoor.ArchipelagoRandomizer;
 
 internal class UIManager
 {
 	public static readonly UIManager instance = new();
+	public static UIManager Instance => instance;
 	private static readonly ConnectionMenu connectionMenu = new();
 	private static readonly NotificationPopup notificationHandler = new();
 
-	public static UIManager Instance => instance;
+	private static string UpdateVersion = "";
+	private static bool UpdateAvailable = false;
 
 	private UIManager() { }
 
@@ -54,4 +60,51 @@ internal class UIManager
 		OptionsToggle optionsToggle = new(itemText: "SKIP CUTSCENES", gameObjectName: "ARCHIPELAGO_UI_ToggleSkipCutscenes", id: "ToggleSkipCutscenes", relevantScenes: [IngameUIManager.RelevantScene.TitleScreen], toggleAction: Archipelago.Instance.ToggleSkipCutscenes, toggleValueInitializer: Archipelago.Instance.InitializeSkipCutscenes, contextText: "BUTTON:CONFIRM Toggle Skip Cutscenes BUTTON:BACK Back");
 		IngameUIManager.AddOptionsMenuItem(optionsToggle);
 	}
+
+	internal void CheckPluginVersion()
+	{
+		UpdateVersion = MyPluginInfo.PLUGIN_VERSION;
+		try
+		{
+			HttpWebRequest Request = (HttpWebRequest)WebRequest.Create("https://api.github.com/repos/Chris-Is-Awesome/DDArchipelagoRandomizer/releases");
+			Request.UserAgent = "request";
+			HttpWebResponse response = (HttpWebResponse)Request.GetResponse();
+			StreamReader Reader = new StreamReader(response.GetResponseStream());
+			string JsonResponse = Reader.ReadToEnd();
+			JArray Releases = JArray.Parse(JsonResponse);
+			UpdateVersion = Releases[0]["tag_name"].ToString();
+			UpdateAvailable = IsNewerVersion(UpdateVersion.Replace("v", ""));
+		}
+		catch (Exception e)
+		{
+			Plugin.Logger.LogInfo(e.Message);
+		}
+		if (UpdateAvailable)
+		{
+			PathUtil.GetByPath("TitleScreen", "UI_PauseCanvas").AddComponent<NotificationDisplay>();
+			Plugin.Logger.LogInfo("Added notification to scene");
+		}
+
+		static bool IsNewerVersion(string newVersion)
+		{
+			Version currentVersion = new Version(MyPluginInfo.PLUGIN_VERSION);
+			Version latestVersion = new Version(newVersion);
+
+			return latestVersion.CompareTo(currentVersion) > 0;
+		}
+	}
+
+	internal void DisplayUpdateNotification()
+	{
+		ShowNotification($"DDArchipelagoRandomizer update available: {UpdateVersion}");
+	}
+
+	private class NotificationDisplay : MonoBehaviour
+	{
+		private void Start()
+		{
+			Instance.DisplayUpdateNotification();
+		}
+	}
+	
 }


### PR DESCRIPTION
Can be tested by lowering the local version before compiling to 0.2.0 or before (since most recent release is 0.2.1).

I also switched the sprite caching for CustomUI to directly reference the objects because the indirect field reference wasn't populated early enough.

Example notification:
<img width="1214" height="153" alt="image" src="https://github.com/user-attachments/assets/511977dc-9d39-4c2f-ba8c-9ed8a0b78457" />

In the long run, we could consider PR'ing a "display update available" feature to ModList instead, but for now, this works regardless of what other mods are installed.
