### PR TITLE
Fix display of souls item number in speech bubbles

### DIFF
--- a/ArchipelagoRandomizer/ItemRandomizer.cs
+++ b/ArchipelagoRandomizer/ItemRandomizer.cs
@@ -410,5 +410,20 @@ internal class ItemRandomizer : MonoBehaviour
 			}
 		}
 
+		/// <summary>
+		/// Replace the item name 100 Souls with the appropriate multiple in dialogue (prefixing ItemChanger)
+		/// </summary>
+		/// <param name="message">The message that ItemChanger is passing in to replace the NPC's speech</param>
+		[HarmonyPrefix]
+		[HarmonyPatch(typeof(IC.SpeechPopup), nameof(IC.SpeechPopup.Modify), [typeof(NPCCharacter), typeof(int), typeof(string)])]
+		private static void PreModify(ref string message)
+		{
+			if (message.Contains("100 Souls"))
+			{
+				int amount = 100 * Instance.SoulMultiplier;
+				message = message.Replace("100 Souls", $"{amount} Souls");
+			}
+		}
+
 	}
 }


### PR DESCRIPTION
Hook's ItemChanger's modification of speech bubbles to change 100 Souls to reflect the local Souls Multiplier