### PR TITLE
Bugfix: place goal item at Rusty Belltower Key

### DIFF
--- a/ArchipelagoRandomizer/ItemRandomizer.cs
+++ b/ArchipelagoRandomizer/ItemRandomizer.cs
@@ -182,6 +182,15 @@ internal class ItemRandomizer : MonoBehaviour
 			Logger.Log($"Placed goal item at Green Ancient Tablet of Knowledge");
 		}
 
+		if (GoalModifications.Instance.IsLordOfDoorsGoal())
+		{
+			// Place a goal item at Rusty Belltower Key if Lord of Doors is a possible goal so that the belltower is accessible
+			IC.Predefined.TryGetItem("Rusty Belltower Key", out IC.Item predefinedItem);
+			IC.Item item = new GoalModifications.GoalItem("Goal", predefinedItem?.Icon ?? "Unknown", "Rusty Belltower Key");
+			icSaveData.Place(item, "Rusty Belltower Key");
+			Logger.Log($"Placed goal item at Rusty Belltower Key");
+		}
+
 		// Determine starting weapon
 		long startWeapon = Archipelago.Instance.GetSlotData<long>("start_weapon");
 		string startingWeaponId = startWeapon switch


### PR DESCRIPTION
Currently, on Lord of Doors and Any goals, the Rusty Belltower location is not created, which means ItemChanger does not allow access to the Belltower, i.e. changing between night and day.

This fix places a dummy goal item on that location to tell ItemChanger to look for the Key item instead (goal should always have triggered before reaching it under these options).