### PR TITLE
Add enemy rando

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -121,7 +121,7 @@ csharp_style_prefer_readonly_struct = true:suggestion
 csharp_style_prefer_readonly_struct_member = true:suggestion
 
 # Code-block preferences
-csharp_prefer_braces = true:suggestion
+csharp_prefer_braces = false:suggestion
 csharp_prefer_simple_using_statement = true:suggestion
 csharp_prefer_system_threading_lock = true:suggestion
 csharp_style_namespace_declarations = file_scoped:suggestion
@@ -243,6 +243,7 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+csharp_style_prefer_implicitly_typed_lambda_expression = true:suggestion
 
 [*.{cs,vb}]
 dotnet_style_operator_placement_when_wrapping = beginning_of_line

--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -384,6 +384,17 @@ internal class Archipelago
 		return apConfig.SkipCutscenes;
 	}
 
+	internal void ToggleEnemyRando(bool newValue)
+	{
+		apConfig.EnemyRando = newValue;
+		apConfig.SaveAPConfig();
+	}
+
+	internal bool InitializeEnemyRando()
+	{
+		return apConfig.EnemyRando;
+	}
+
 	private APSaveData GetAPSaveDataForSlot(int saveIndex)
 	{
 		if (saveIndex > apSaveDataSlots.Length || saveIndex <= 0)
@@ -473,6 +484,7 @@ internal class Archipelago
 		public bool DeathLinkEnabled { get; set; } = false;
 		public bool ReceiveItemsFast { get; set; } = false;
 		public bool SkipCutscenes { get; set; } = false;
+		public bool EnemyRando { get; set; } = false;
 
 		internal void SaveAPConfig()
 		{

--- a/ArchipelagoRandomizer/ArchipelagoRandomizerMod.cs
+++ b/ArchipelagoRandomizer/ArchipelagoRandomizerMod.cs
@@ -69,6 +69,7 @@ internal class ArchipelagoRandomizerMod
 			{
 				archipelagoRandomizer = new GameObject("ArchipelagoRandomizer");
 				ItemRandomizer itemRando = archipelagoRandomizer.AddComponent<ItemRandomizer>();
+				EnemyRandomizer enemyRando = archipelagoRandomizer.AddComponent<EnemyRandomizer>();
 				GoalModifications goalMods = archipelagoRandomizer.AddComponent<GoalModifications>();
 				MapManager mapManager = archipelagoRandomizer.AddComponent<MapManager>();
 				TrapManager trapManager = archipelagoRandomizer.AddComponent<TrapManager>();
@@ -79,6 +80,8 @@ internal class ArchipelagoRandomizerMod
 				saveMenu.saveSlots[saveMenu.index].LoadSave();
 				GameSave.currentSave.SetKeyState("ArchipelagoRandomizer", true);
 				GameSave.currentSave.Save();
+
+				Preloader.Instance.StartPreload();
 			}
 		}
 		catch (LoginValidationException ex)

--- a/ArchipelagoRandomizer/ArchipelagoRandomizerMod.cs
+++ b/ArchipelagoRandomizer/ArchipelagoRandomizerMod.cs
@@ -69,7 +69,7 @@ internal class ArchipelagoRandomizerMod
 			{
 				archipelagoRandomizer = new GameObject("ArchipelagoRandomizer");
 				ItemRandomizer itemRando = archipelagoRandomizer.AddComponent<ItemRandomizer>();
-				EnemyRandomizer enemyRando = archipelagoRandomizer.AddComponent<EnemyRandomizer>();
+				EnemyRandomizer enemyRando = Archipelago.Instance.apConfig.EnemyRando ? archipelagoRandomizer.AddComponent<EnemyRandomizer>() : null;
 				GoalModifications goalMods = archipelagoRandomizer.AddComponent<GoalModifications>();
 				MapManager mapManager = archipelagoRandomizer.AddComponent<MapManager>();
 				TrapManager trapManager = archipelagoRandomizer.AddComponent<TrapManager>();

--- a/ArchipelagoRandomizer/EnemyRandomizer.cs
+++ b/ArchipelagoRandomizer/EnemyRandomizer.cs
@@ -174,6 +174,8 @@ internal class EnemyRandomizer : MonoBehaviour
 			"FROG_BOSS_FAT",
 			"FROG_BOSS_MAIN",
 			"betty_boss",
+			"OLD_CROW_BOSS(old)",
+			"old_crow_boss_fbx",
 		};
 
 		// Setup enemyType -> EnemyData lookup dict

--- a/ArchipelagoRandomizer/EnemyRandomizer.cs
+++ b/ArchipelagoRandomizer/EnemyRandomizer.cs
@@ -1,0 +1,259 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace DDoor.ArchipelagoRandomizer;
+
+internal class EnemyRandomizer : MonoBehaviour
+{
+	public enum Enemy
+	{
+		BatBlack,
+		BatWhite,
+		Brute,
+		BruteGold,
+		DekuScrub,
+		Dodger,
+		Fireplant,
+		FireplantNoHookshot,
+		Ghoul,
+		GhoulLongRange,
+		GhoulRapid,
+		GrimaceKnight,
+		Grunt,
+		GruntFrog,
+		GruntGrave,
+		GruntPot,
+		GruntRedeemer,
+		GruntRedeemerIndoor,
+		GruntYeti,
+		Headroller,
+		HeadrollerHeadless,
+		Jumper,
+		Knight,
+		KnightGreenPlague,
+		Lurker,
+		LurkerMother,
+		Mage,
+		MageFire,
+		MageGrounded,
+		MagePlague,
+		MagePlagueSingleshot,
+		MageRedPurple,
+		PlagueKnight,
+		PlagueKnightSlowFire,
+		Plant,
+		ServantAll,
+		ServantBomb,
+		ServantFire,
+		ServantHookshot,
+		SlimeBig,
+		SlimeBigGreen,
+		SlimeMed,
+		SlimeMedGreen,
+		SlimeSmall,
+		SlimeSmallGreen,
+	}
+
+	private static EnemyRandomizer instance;
+	private Dictionary<string, EnemyData[]> enemiesToCache;
+
+	public static EnemyRandomizer Instance => instance;
+
+	private void Awake()
+	{
+		instance = this;
+		enemiesToCache = new()
+		{
+			{"AVARICE_WAVES_Secret", [
+				new EnemyData { type = Enemy.Lurker, name = "_E_LURKER" },
+				new EnemyData { type = Enemy.Knight, name = "_E_KNIGHT" },
+				new EnemyData { type = Enemy.MageRedPurple, name = "_E_MAGE_REDPURPLE Variant" },
+				new EnemyData { type = Enemy.BruteGold, name = "_E_BRUTE_GOLD Variant" },
+				new EnemyData { type = Enemy.GruntRedeemerIndoor, name = "_E_GRUNT_Redeemer_Indoor Variant" },
+				new EnemyData { type = Enemy.MagePlagueSingleshot, name = "_E_MAGE_Plague_SingleShot" },
+				new EnemyData { type = Enemy.BatWhite, name = "_E_BAT_White" },
+				new EnemyData { type = Enemy.GhoulRapid, name = "_E_GHOUL_Rapid Variant" },
+				new EnemyData { type = Enemy.LurkerMother, name = "_E_LURKER_MOTHER" },
+			]},
+			{"lvl_Forest", [
+				new EnemyData { type = Enemy.DekuScrub, name = "_E_DEKU_SCRUB" },
+				new EnemyData { type = Enemy.Plant, name = "_E_PLANT" },
+			]},
+			{"lvl_Graveyard", [
+				new EnemyData { type = Enemy.GruntRedeemer, name = "_E_GRUNT_Redeemer" },
+				new EnemyData { type = Enemy.GruntGrave, name = "_E_GRUNT_Grave Variant" },
+				new EnemyData { type = Enemy.BatBlack, name = "_E_BAT_Black Variant" },
+				new EnemyData { type = Enemy.HeadrollerHeadless, name = "_E_HEADROLLER_HEADLESS Variant" },
+			]},
+			{"lvl_GrandmaGardens", [
+				new EnemyData { type = Enemy.SlimeMedGreen, name = "_E_Slime_med_GREEN Variant" },
+				new EnemyData { type = Enemy.SlimeSmallGreen, name = "_E_Slime_small_GREEN Variant" },
+				new EnemyData { type = Enemy.SlimeBigGreen, name = "_E_Slime_big_GREEN Variant" },
+			]},
+			{"lvl_Swamp", [
+				new EnemyData { type = Enemy.FireplantNoHookshot, name = "_E_FIREPLANT_Nohookshot" },
+				new EnemyData { type = Enemy.GhoulLongRange, name = "_E_GHOUL_LongRange Variant" },
+				new EnemyData { type = Enemy.Grunt, name = "_E_GRUNT" },
+				new EnemyData { type = Enemy.MagePlague, name = "_E_MAGE_Plague Variant" },
+			]},
+			{"lvl_mountaintops", [
+				new EnemyData { type = Enemy.Brute, name = "_E_BRUTE" },
+				new EnemyData { type = Enemy.Fireplant, name = "_E_FIREPLANT" },
+				new EnemyData { type = Enemy.MageGrounded, name = "_E_MAGE_Grounded Variant" },
+			]},
+			{"AVARICE_WAVES_Fortress", [
+				new EnemyData { type = Enemy.SlimeSmall, name = "_E_Slime_small" },
+				new EnemyData { type = Enemy.Jumper, name = "_E_JUMPER" },
+				new EnemyData { type = Enemy.SlimeMed, name = "_E_Slime_med" },
+				new EnemyData { type = Enemy.MageFire, name = "_E_MAGE_Fire Variant" },
+				new EnemyData { type = Enemy.GruntYeti, name = "_E_GRUNT_Yeti Variant" },
+			]},
+			{"lvl_SailorMountain", [
+				new EnemyData { type = Enemy.PlagueKnightSlowFire, name = "_E_PLAGUE_KNIGHT_SlowFire" },
+			]},
+			{"lvl_GrandmaBasement", [
+				new EnemyData { type = Enemy.SlimeBig, name = "_E_Slime_big" },
+				new EnemyData { type = Enemy.Headroller, name = "_E_HEADROLLER" },
+				new EnemyData { type = Enemy.PlagueKnight, name = "_E_PLAGUE_KNIGHT" },
+			]},
+			{"TEST_AREA", [
+				new EnemyData { type = Enemy.Mage, name = "_E_MAGE" },
+				new EnemyData { type = Enemy.GruntPot, name = "_E_GRUNT_Pot Variant" },
+				new EnemyData { type = Enemy.GrimaceKnight, name = "_E_GRIMACE_KNIGHT" },
+				new EnemyData { type = Enemy.Dodger, name = "_E_DODGER" },
+				new EnemyData { type = Enemy.KnightGreenPlague, name = "_E_KNIGHT_GreenPlague" },
+				new EnemyData { type = Enemy.Ghoul, name = "_E_GHOUL" },
+			]},
+			{"lvl_SilentServant_Fight", [
+				new EnemyData { type = Enemy.ServantAll, name = "_E_SERVANT_All" },
+				new EnemyData { type = Enemy.ServantBomb, name = "_E_SERVANT_Bombs" },
+				new EnemyData { type = Enemy.ServantFire, name = "_E_SERVANT_FIRE Variant" },
+				new EnemyData { type = Enemy.ServantHookshot, name = "_E_SERVANT_Hookshot Variant" },
+			]},
+			{"boss_Frog", [
+				new EnemyData { type = Enemy.GruntFrog, name = "_E_GRUNT_Frog" },
+			]},
+		};
+	}
+
+	private void OnEnable()
+	{
+		Logger.Log("Enemy randomizer started!");
+
+		foreach (var kvp in enemiesToCache)
+		{
+			string sceneName = kvp.Key;
+			EnemyData[] dataForEnemies = kvp.Value;
+
+			Preloader.Instance.AddObjectToCacheList(sceneName, () =>
+			{
+				List<GameObject> enemies = new();
+
+				foreach (EnemyData enemyData in dataForEnemies)
+				{
+					GameObject foundEnemy = null;
+
+					foreach (AI_Brain brain in Resources.FindObjectsOfTypeAll<AI_Brain>())
+					{
+						if (brain.name == enemyData.name)
+						{
+							foundEnemy = brain.gameObject;
+							foundEnemy.SetActive(true);
+
+							// Modify silent servants
+							if (foundEnemy.TryGetComponent(out AI_SilentServant ai))
+							{
+								DestroyImmediate(ai.GetComponentInChildren<CameraFocusObjectLimited>(true).gameObject);
+								ai.hasHookshot = false;
+
+								if (enemyData.type == Enemy.ServantAll)
+								{
+									ai.hasAllPowers = false;
+									ai.hasBombs = true;
+									ai.hasFire = true;
+								}
+							}
+						}
+					}
+
+					if (foundEnemy == null)
+					{
+						Logger.LogError($"During enemy rando preload, failed to find enemy\n    {enemyData.name}\n    in {sceneName}");
+						continue;
+					}
+
+					enemies.Add(foundEnemy);
+				}
+
+				Logger.Log($"Finished caching enemies for scene {sceneName}!");
+				return enemies.ToArray();
+			});
+		}
+	}
+
+	// TODO: Remove this, as this is for quick testing before figuring out enemy replacements
+	int index = 0;
+	private void Update()
+	{
+		if (Input.GetKeyDown("t"))
+		{
+			SpawnEnemyAtPlayer((Enemy)index);
+			index++;
+		}
+	}
+
+	public GameObject SpawnEnemyAtPlayer(Enemy enemyType)
+	{
+		Logger.LogError("test");
+		Transform player = PlayerGlobal.instance.transform;
+		Vector3 position = player.position - player.forward * 2f;
+		GameObject enemy = Instantiate(GetEnemy(enemyType));
+		enemy.transform.position = position;
+		return enemy;
+	}
+
+	private GameObject GetEnemy(Enemy enemyType)
+	{
+		foreach (EnemyData data in enemiesToCache.Values.SelectMany(x => x))
+		{
+			if (data.type == enemyType)
+			{
+				return Preloader.GetCachedObject<GameObject>(data.name);
+			}
+		}
+
+		Logger.LogError($"No enemy {enemyType} was found in preload list");
+		return null;
+	}
+
+	private IEnumerator SilentServantDeath(AI_SilentServant servant)
+	{
+		yield return new WaitForSeconds(3);
+		Destroy(servant.gameObject);
+	}
+
+	private struct EnemyData
+	{
+		public Enemy type;
+		public string name;
+	}
+
+	[HarmonyPatch]
+	private class Patches
+	{
+		// Removes the corpse of killed silent servants, as the cutscene that removes them doesn't play
+		[HarmonyPostfix]
+		[HarmonyPatch(typeof(AI_SilentServant), nameof(AI_SilentServant.OnDeath))]
+		private static void SilentServantDeathRemoveCorpsePatch(AI_SilentServant __instance)
+		{
+			if (!Archipelago.Instance.IsConnected())
+				return;
+
+			Instance.StartCoroutine(Instance.SilentServantDeath(__instance));
+		}
+	}
+}

--- a/ArchipelagoRandomizer/EnemyRandomizer.cs
+++ b/ArchipelagoRandomizer/EnemyRandomizer.cs
@@ -1,14 +1,18 @@
 ﻿using HarmonyLib;
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.SceneManagement;
+using Random = UnityEngine.Random;
 
 namespace DDoor.ArchipelagoRandomizer;
 
 internal class EnemyRandomizer : MonoBehaviour
 {
-	public enum Enemy
+	public enum EnemyType
 	{
 		BatBlack,
 		BatWhite,
@@ -45,6 +49,12 @@ internal class EnemyRandomizer : MonoBehaviour
 		PlagueKnight,
 		PlagueKnightSlowFire,
 		Plant,
+		PotMimicAvariceExplode,
+		PotMimicAvariceMagic,
+		PotMimicAvariceMelee,
+		PotMimicExplode,
+		PotMimicMagic,
+		PotMimicMelee,
 		ServantAll,
 		ServantBomb,
 		ServantFire,
@@ -58,7 +68,10 @@ internal class EnemyRandomizer : MonoBehaviour
 	}
 
 	private static EnemyRandomizer instance;
+	private static readonly Array enemyValues = Enum.GetValues(typeof(EnemyType));
 	private Dictionary<string, EnemyData[]> enemiesToCache;
+	private Dictionary<EnemyType, EnemyData> enemyTypeLookup = new();
+	private List<string> enemiesToNotReplace;
 
 	public static EnemyRandomizer Instance => instance;
 
@@ -68,80 +81,116 @@ internal class EnemyRandomizer : MonoBehaviour
 		enemiesToCache = new()
 		{
 			{"AVARICE_WAVES_Secret", [
-				new EnemyData { type = Enemy.Lurker, name = "_E_LURKER" },
-				new EnemyData { type = Enemy.Knight, name = "_E_KNIGHT" },
-				new EnemyData { type = Enemy.MageRedPurple, name = "_E_MAGE_REDPURPLE Variant" },
-				new EnemyData { type = Enemy.BruteGold, name = "_E_BRUTE_GOLD Variant" },
-				new EnemyData { type = Enemy.GruntRedeemerIndoor, name = "_E_GRUNT_Redeemer_Indoor Variant" },
-				new EnemyData { type = Enemy.MagePlagueSingleshot, name = "_E_MAGE_Plague_SingleShot" },
-				new EnemyData { type = Enemy.BatWhite, name = "_E_BAT_White" },
-				new EnemyData { type = Enemy.GhoulRapid, name = "_E_GHOUL_Rapid Variant" },
-				new EnemyData { type = Enemy.LurkerMother, name = "_E_LURKER_MOTHER" },
+				new EnemyData { type = EnemyType.Lurker, name = "_E_LURKER" },
+				new EnemyData { type = EnemyType.Knight, name = "_E_KNIGHT" },
+				new EnemyData { type = EnemyType.MageRedPurple, name = "_E_MAGE_REDPURPLE Variant" },
+				new EnemyData { type = EnemyType.BruteGold, name = "_E_BRUTE_GOLD Variant" },
+				new EnemyData { type = EnemyType.GruntRedeemerIndoor, name = "_E_GRUNT_Redeemer_Indoor Variant" },
+				new EnemyData { type = EnemyType.MagePlagueSingleshot, name = "_E_MAGE_Plague_SingleShot" },
+				new EnemyData { type = EnemyType.BatWhite, name = "_E_BAT_White" },
+				new EnemyData { type = EnemyType.GhoulRapid, name = "_E_GHOUL_Rapid Variant" },
+				new EnemyData { type = EnemyType.LurkerMother, name = "_E_LURKER_MOTHER" },
 			]},
 			{"lvl_Forest", [
-				new EnemyData { type = Enemy.DekuScrub, name = "_E_DEKU_SCRUB" },
-				new EnemyData { type = Enemy.Plant, name = "_E_PLANT" },
+				new EnemyData { type = EnemyType.DekuScrub, name = "_E_DEKU_SCRUB" },
+				new EnemyData { type = EnemyType.Plant, name = "_E_PLANT" },
 			]},
 			{"lvl_Graveyard", [
-				new EnemyData { type = Enemy.GruntRedeemer, name = "_E_GRUNT_Redeemer" },
-				new EnemyData { type = Enemy.GruntGrave, name = "_E_GRUNT_Grave Variant" },
-				new EnemyData { type = Enemy.BatBlack, name = "_E_BAT_Black Variant" },
-				new EnemyData { type = Enemy.HeadrollerHeadless, name = "_E_HEADROLLER_HEADLESS Variant" },
+				new EnemyData { type = EnemyType.GruntRedeemer, name = "_E_GRUNT_Redeemer" },
+				new EnemyData { type = EnemyType.GruntGrave, name = "_E_GRUNT_Grave Variant" },
+				new EnemyData { type = EnemyType.BatBlack, name = "_E_BAT_Black Variant" },
+				new EnemyData { type = EnemyType.HeadrollerHeadless, name = "_E_HEADROLLER_HEADLESS Variant" },
 			]},
 			{"lvl_GrandmaGardens", [
-				new EnemyData { type = Enemy.SlimeMedGreen, name = "_E_Slime_med_GREEN Variant" },
-				new EnemyData { type = Enemy.SlimeSmallGreen, name = "_E_Slime_small_GREEN Variant" },
-				new EnemyData { type = Enemy.SlimeBigGreen, name = "_E_Slime_big_GREEN Variant" },
+				new EnemyData { type = EnemyType.SlimeMedGreen, name = "_E_Slime_med_GREEN Variant" },
+				new EnemyData { type = EnemyType.SlimeSmallGreen, name = "_E_Slime_small_GREEN Variant" },
+				new EnemyData { type = EnemyType.SlimeBigGreen, name = "_E_Slime_big_GREEN Variant" },
+				new EnemyData { type = EnemyType.PotMimicAvariceExplode, name = "POT_Mimic_Explode_AVARICE Variant" },
+				new EnemyData { type = EnemyType.PotMimicAvariceMagic, name = "POT_Mimic_Magic_AVARICE Variant" },
+				new EnemyData { type = EnemyType.PotMimicAvariceMelee, name = "POT_Mimic_Melee_AVARICE Variant" },
+			]},
+			{"lvl_GrandmaMansion", [
+				new EnemyData { type = EnemyType.PotMimicMagic, name = "POT_Mimic_Magic" },
+				new EnemyData { type = EnemyType.PotMimicExplode, name = "POT_Mimic_Explode" },
+				new EnemyData { type = EnemyType.PotMimicMelee, name = "POT_Mimic_Melee" },
 			]},
 			{"lvl_Swamp", [
-				new EnemyData { type = Enemy.FireplantNoHookshot, name = "_E_FIREPLANT_Nohookshot" },
-				new EnemyData { type = Enemy.GhoulLongRange, name = "_E_GHOUL_LongRange Variant" },
-				new EnemyData { type = Enemy.Grunt, name = "_E_GRUNT" },
-				new EnemyData { type = Enemy.MagePlague, name = "_E_MAGE_Plague Variant" },
+				new EnemyData { type = EnemyType.FireplantNoHookshot, name = "_E_FIREPLANT_Nohookshot" },
+				new EnemyData { type = EnemyType.GhoulLongRange, name = "_E_GHOUL_LongRange Variant" },
+				new EnemyData { type = EnemyType.Grunt, name = "_E_GRUNT" },
+				new EnemyData { type = EnemyType.MagePlague, name = "_E_MAGE_Plague Variant" },
 			]},
 			{"lvl_mountaintops", [
-				new EnemyData { type = Enemy.Brute, name = "_E_BRUTE" },
-				new EnemyData { type = Enemy.Fireplant, name = "_E_FIREPLANT" },
-				new EnemyData { type = Enemy.MageGrounded, name = "_E_MAGE_Grounded Variant" },
+				new EnemyData { type = EnemyType.Brute, name = "_E_BRUTE" },
+				new EnemyData { type = EnemyType.Fireplant, name = "_E_FIREPLANT" },
+				new EnemyData { type = EnemyType.MageGrounded, name = "_E_MAGE_Grounded Variant" },
 			]},
 			{"AVARICE_WAVES_Fortress", [
-				new EnemyData { type = Enemy.SlimeSmall, name = "_E_Slime_small" },
-				new EnemyData { type = Enemy.Jumper, name = "_E_JUMPER" },
-				new EnemyData { type = Enemy.SlimeMed, name = "_E_Slime_med" },
-				new EnemyData { type = Enemy.MageFire, name = "_E_MAGE_Fire Variant" },
-				new EnemyData { type = Enemy.GruntYeti, name = "_E_GRUNT_Yeti Variant" },
+				new EnemyData { type = EnemyType.SlimeSmall, name = "_E_Slime_small" },
+				new EnemyData { type = EnemyType.Jumper, name = "_E_JUMPER" },
+				new EnemyData { type = EnemyType.SlimeMed, name = "_E_Slime_med" },
+				new EnemyData { type = EnemyType.MageFire, name = "_E_MAGE_Fire Variant" },
+				new EnemyData { type = EnemyType.GruntYeti, name = "_E_GRUNT_Yeti Variant" },
 			]},
 			{"lvl_SailorMountain", [
-				new EnemyData { type = Enemy.PlagueKnightSlowFire, name = "_E_PLAGUE_KNIGHT_SlowFire" },
+				new EnemyData { type = EnemyType.PlagueKnightSlowFire, name = "_E_PLAGUE_KNIGHT_SlowFire" },
 			]},
 			{"lvl_GrandmaBasement", [
-				new EnemyData { type = Enemy.SlimeBig, name = "_E_Slime_big" },
-				new EnemyData { type = Enemy.Headroller, name = "_E_HEADROLLER" },
-				new EnemyData { type = Enemy.PlagueKnight, name = "_E_PLAGUE_KNIGHT" },
+				new EnemyData { type = EnemyType.SlimeBig, name = "_E_Slime_big" },
+				new EnemyData { type = EnemyType.Headroller, name = "_E_HEADROLLER" },
+				new EnemyData { type = EnemyType.PlagueKnight, name = "_E_PLAGUE_KNIGHT" },
 			]},
 			{"TEST_AREA", [
-				new EnemyData { type = Enemy.Mage, name = "_E_MAGE" },
-				new EnemyData { type = Enemy.GruntPot, name = "_E_GRUNT_Pot Variant" },
-				new EnemyData { type = Enemy.GrimaceKnight, name = "_E_GRIMACE_KNIGHT" },
-				new EnemyData { type = Enemy.Dodger, name = "_E_DODGER" },
-				new EnemyData { type = Enemy.KnightGreenPlague, name = "_E_KNIGHT_GreenPlague" },
-				new EnemyData { type = Enemy.Ghoul, name = "_E_GHOUL" },
+				new EnemyData { type = EnemyType.Mage, name = "_E_MAGE" },
+				new EnemyData { type = EnemyType.GruntPot, name = "_E_GRUNT_Pot Variant" },
+				new EnemyData { type = EnemyType.GrimaceKnight, name = "_E_GRIMACE_KNIGHT" },
+				new EnemyData { type = EnemyType.Dodger, name = "_E_DODGER" },
+				new EnemyData { type = EnemyType.KnightGreenPlague, name = "_E_KNIGHT_GreenPlague" },
+				new EnemyData { type = EnemyType.Ghoul, name = "_E_GHOUL" },
 			]},
 			{"lvl_SilentServant_Fight", [
-				new EnemyData { type = Enemy.ServantAll, name = "_E_SERVANT_All" },
-				new EnemyData { type = Enemy.ServantBomb, name = "_E_SERVANT_Bombs" },
-				new EnemyData { type = Enemy.ServantFire, name = "_E_SERVANT_FIRE Variant" },
-				new EnemyData { type = Enemy.ServantHookshot, name = "_E_SERVANT_Hookshot Variant" },
+				new EnemyData { type = EnemyType.ServantAll, name = "_E_SERVANT_All" },
+				new EnemyData { type = EnemyType.ServantBomb, name = "_E_SERVANT_Bombs" },
+				new EnemyData { type = EnemyType.ServantFire, name = "_E_SERVANT_FIRE Variant" },
+				new EnemyData { type = EnemyType.ServantHookshot, name = "_E_SERVANT_Hookshot Variant" },
 			]},
 			{"boss_Frog", [
-				new EnemyData { type = Enemy.GruntFrog, name = "_E_GRUNT_Frog" },
+				new EnemyData { type = EnemyType.GruntFrog, name = "_E_GRUNT_Frog" },
 			]},
 		};
+		enemiesToNotReplace = new()
+		{
+			"redeemer_BOSS",
+			"redeemer_cutscene",
+			"BOSS_GraveDigger",
+			"_FORESTMOTHER_BOSS",
+			"BOSS_lord_of_doors NEW",
+			"BOSS_lord_of_doors_Betty",
+			"BOSS_lord_of_doors_Garden",
+			"lord_of_doors",
+			"lord_of_doorsOLD",
+			"BOSS_lord_of_doors_Forest",
+			"grandma",
+			"oldfrog",
+			"FROG_BOSS_FAT",
+			"FROG_BOSS_MAIN",
+			"betty_boss",
+		};
+
+		// Setup enemyType -> EnemyData lookup dict
+		foreach (EnemyData[] dataArr in enemiesToCache.Values)
+		{
+			foreach (EnemyData data in dataArr)
+			{
+				if (!enemyTypeLookup.ContainsKey(data.type))
+					enemyTypeLookup.Add(data.type, data);
+			}
+		}
 	}
 
 	private void OnEnable()
 	{
-		Logger.Log("Enemy randomizer started!");
+		Logger.Log("EnemyType randomizer started!");
 
 		// Preload enemies
 		foreach (var kvp in enemiesToCache)
@@ -170,7 +219,7 @@ internal class EnemyRandomizer : MonoBehaviour
 								DestroyImmediate(ai.GetComponentInChildren<CameraFocusObjectLimited>(true).gameObject);
 								ai.hasHookshot = false;
 
-								if (enemyData.type == Enemy.ServantAll)
+								if (enemyData.type == EnemyType.ServantAll)
 								{
 									ai.hasAllPowers = false;
 									ai.hasBombs = true;
@@ -193,20 +242,39 @@ internal class EnemyRandomizer : MonoBehaviour
 				return enemies.ToArray();
 			});
 		}
+
+		Preloader.Instance.OnPreloadDone += AfterPreload;
 	}
 
-	// TODO: Remove this, as this is for quick testing before figuring out enemy replacements
-	int index = 0;
-	private void Update()
+	private void OnDisable()
 	{
-		if (Input.GetKeyDown("t"))
-		{
-			SpawnEnemyAtPlayer((Enemy)index);
-			index++;
-		}
+		Preloader.Instance.OnPreloadDone -= AfterPreload;
+		SceneManager.sceneLoaded -= SceneLoaded;
 	}
 
-	public GameObject SpawnEnemyAtPlayer(Enemy enemyType)
+	//TODO: Remove this, as this is for quick testing before figuring out enemy replacements
+
+	//int index = 0;
+	//private void Update()
+	//{
+	//	if (Input.GetKeyDown("t"))
+	//	{
+	//		SpawnEnemyAtPlayer((EnemyType)index);
+	//		index++;
+	//	}
+	//}
+
+	private void AfterPreload()
+	{
+		SceneManager.sceneLoaded += SceneLoaded;
+	}
+
+	private void SceneLoaded(Scene scene, LoadSceneMode _)
+	{
+		ReplaceEnemiesInScene();
+	}
+
+	public GameObject SpawnEnemyAtPlayer(EnemyType enemyType)
 	{
 		Transform player = PlayerGlobal.instance.transform;
 		Vector3 position = player.position - player.forward * 2f;
@@ -215,17 +283,97 @@ internal class EnemyRandomizer : MonoBehaviour
 		return enemy;
 	}
 
-	private GameObject GetEnemy(Enemy enemyType)
+	private void ReplaceEnemiesInScene()
 	{
-		foreach (EnemyData data in enemiesToCache.Values.SelectMany(x => x))
+		Stopwatch sw = Stopwatch.StartNew();
+		Scene scene = SceneManager.GetActiveScene();
+
+		foreach (GameObject rootObj in scene.GetRootGameObjects())
 		{
-			if (data.type == enemyType)
+			foreach (Component comp in rootObj.GetComponentsInChildren<Component>(true))
 			{
-				return Preloader.GetCachedObject<GameObject>(data.name);
+				GameObject replacement = null;
+
+				switch (comp)
+				{
+					// Replace enemies that don't spawn from spawners
+					case AI_Brain brain:
+						// Don't replace silent servants because there's no good way to trigger
+						// the death cutscene afterwards, so player gets stuck and gets no item
+						if (brain is AI_SilentServant)
+							break;
+
+						replacement = GetEnemyReplalcement(comp);
+
+						if (replacement == null)
+							break;
+
+						Vector3 enemyPos = brain.transform.position;
+						Transform enemyParent = brain.transform.parent;
+						Destroy(brain.gameObject);
+						GameObject newEnemy = Instantiate(replacement, enemyParent);
+						newEnemy.transform.position = enemyPos;
+						break;
+					// Replace enemies that spawn from spawners
+					case WaveEnemy wave:
+						replacement = GetEnemyReplalcement(comp);
+
+						if (replacement == null)
+							break;
+
+						wave.prefab = replacement;
+						break;
+					// Replace enemies that spawn from eggs (Lurkers)
+					case LurkerEgg egg:
+						replacement = GetEnemyReplalcement(comp);
+
+						if (replacement == null)
+							break;
+
+						egg.contentsPrefab = replacement;
+						break;
+				}
 			}
 		}
 
-		Logger.LogError($"No enemy {enemyType} was found in preload list");
+		sw.Stop();
+		Logger.Log($"Took {sw.ElapsedMilliseconds}ms to replace all enemies in {scene.name}");
+	}
+
+	private GameObject GetEnemyReplalcement(Component comp)
+	{
+		string enemyName = comp switch
+		{
+			AI_Brain brain => brain.name,
+			WaveEnemy wave => wave.prefab.name,
+			LurkerEgg egg => egg.contentsPrefab.name,
+			_ => ""
+		};
+
+		// Ignore exclusions
+		if (enemiesToNotReplace.Contains(enemyName))
+			return null;
+
+		GameObject randomEnemy = GetRandomEnemy();
+		return randomEnemy;
+	}
+
+	private GameObject GetRandomEnemy()
+	{
+		EnemyType[] types = enemyTypeLookup.Keys.ToArray();
+		int randomIndex = Random.Range(0, types.Length);
+		EnemyType randomEnemy = types[randomIndex];
+		return GetEnemy(randomEnemy);
+	}
+
+	private GameObject GetEnemy(EnemyType enemyType)
+	{
+		if (enemyTypeLookup.TryGetValue(enemyType, out EnemyData data))
+		{
+			return Preloader.GetCachedObject<GameObject>(data.name);
+		}
+
+		Logger.LogError($"No enemy {enemyType} was found in cache list");
 		return null;
 	}
 
@@ -237,7 +385,7 @@ internal class EnemyRandomizer : MonoBehaviour
 
 	private struct EnemyData
 	{
-		public Enemy type;
+		public EnemyType type;
 		public string name;
 	}
 
@@ -253,6 +401,28 @@ internal class EnemyRandomizer : MonoBehaviour
 				return;
 
 			Instance.StartCoroutine(Instance.SilentServantDeath(__instance));
+		}
+
+		// Spawns the randomized enemy whewn a Lurker (spider) egg explodes
+		[HarmonyPrefix]
+		[HarmonyPatch(typeof(LurkerEgg), nameof(LurkerEgg.Explode))]
+		private static bool LurkerEggExplodePatch(LurkerEgg __instance, Vector3 source, float modifier = 1f)
+		{
+			if (!__instance.didExplode)
+			{
+				__instance.didExplode = true;
+				Vector3 vector = __instance.transform.position - source;
+				vector.Normalize();
+				vector.x += Random.Range(-0.1f, 0.1f);
+				vector.z += Random.Range(-0.1f, 0.1f);
+				float y = Mathf.Atan2(vector.x, vector.z) * 57.29578f;
+				GameObject gameObject = Instantiate(__instance.contentsPrefab, __instance.transform.position, Quaternion.Euler(0f, y, 0f));
+				gameObject.transform.SetParent(GameRoom.GetCurrentContents());
+				Destroy(__instance.gameObject);
+				return false;
+			}
+
+			return true;
 		}
 	}
 }

--- a/ArchipelagoRandomizer/EnemyRandomizer.cs
+++ b/ArchipelagoRandomizer/EnemyRandomizer.cs
@@ -42,7 +42,6 @@ internal class EnemyRandomizer : MonoBehaviour
 		LurkerMother,
 		Mage,
 		MageFire,
-		MageGrounded,
 		MagePlague,
 		MagePlagueSingleshot,
 		MageRedPurple,
@@ -72,6 +71,7 @@ internal class EnemyRandomizer : MonoBehaviour
 	private Dictionary<string, EnemyData[]> enemiesToCache;
 	private Dictionary<EnemyType, EnemyData> enemyTypeLookup = new();
 	private List<string> enemiesToNotReplace;
+	private bool hasSpawnedFireColumn;
 
 	public static EnemyRandomizer Instance => instance;
 
@@ -81,81 +81,80 @@ internal class EnemyRandomizer : MonoBehaviour
 		enemiesToCache = new()
 		{
 			{"AVARICE_WAVES_Secret", [
-				new EnemyData { type = EnemyType.Lurker, name = "_E_LURKER" },
-				new EnemyData { type = EnemyType.Knight, name = "_E_KNIGHT" },
-				new EnemyData { type = EnemyType.MageRedPurple, name = "_E_MAGE_REDPURPLE Variant" },
-				new EnemyData { type = EnemyType.BruteGold, name = "_E_BRUTE_GOLD Variant" },
-				new EnemyData { type = EnemyType.GruntRedeemerIndoor, name = "_E_GRUNT_Redeemer_Indoor Variant" },
-				new EnemyData { type = EnemyType.MagePlagueSingleshot, name = "_E_MAGE_Plague_SingleShot" },
-				new EnemyData { type = EnemyType.BatWhite, name = "_E_BAT_White" },
-				new EnemyData { type = EnemyType.GhoulRapid, name = "_E_GHOUL_Rapid Variant" },
-				new EnemyData { type = EnemyType.LurkerMother, name = "_E_LURKER_MOTHER" },
+				new EnemyData { type = EnemyType.Lurker, name = "_E_LURKER", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.Knight, name = "_E_KNIGHT", weightTier = EnemyData.WeightTier.Tier4 },
+				new EnemyData { type = EnemyType.MageRedPurple, name = "_E_MAGE_REDPURPLE Variant", weightTier = EnemyData.WeightTier.Tier2 },
+				new EnemyData { type = EnemyType.BruteGold, name = "_E_BRUTE_GOLD Variant", weightTier = EnemyData.WeightTier.Tier3 },
+				new EnemyData { type = EnemyType.GruntRedeemerIndoor, name = "_E_GRUNT_Redeemer_Indoor Variant", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.MagePlagueSingleshot, name = "_E_MAGE_Plague_SingleShot", weightTier = EnemyData.WeightTier.Tier2 },
+				new EnemyData { type = EnemyType.BatWhite, name = "_E_BAT_White", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.GhoulRapid, name = "_E_GHOUL_Rapid Variant", weightTier = EnemyData.WeightTier.Tier2 },
+				new EnemyData { type = EnemyType.LurkerMother, name = "_E_LURKER_MOTHER", weightTier = EnemyData.WeightTier.Tier3 },
 			]},
 			{"lvl_Forest", [
-				new EnemyData { type = EnemyType.DekuScrub, name = "_E_DEKU_SCRUB" },
-				new EnemyData { type = EnemyType.Plant, name = "_E_PLANT" },
+				new EnemyData { type = EnemyType.DekuScrub, name = "_E_DEKU_SCRUB", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.Plant, name = "_E_PLANT", weightTier = EnemyData.WeightTier.Tier1 },
 			]},
 			{"lvl_Graveyard", [
-				new EnemyData { type = EnemyType.GruntRedeemer, name = "_E_GRUNT_Redeemer" },
-				new EnemyData { type = EnemyType.GruntGrave, name = "_E_GRUNT_Grave Variant" },
-				new EnemyData { type = EnemyType.BatBlack, name = "_E_BAT_Black Variant" },
-				new EnemyData { type = EnemyType.HeadrollerHeadless, name = "_E_HEADROLLER_HEADLESS Variant" },
+				new EnemyData { type = EnemyType.GruntRedeemer, name = "_E_GRUNT_Redeemer", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.GruntGrave, name = "_E_GRUNT_Grave Variant", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.BatBlack, name = "_E_BAT_Black Variant", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.HeadrollerHeadless, name = "_E_HEADROLLER_HEADLESS Variant", weightTier = EnemyData.WeightTier.Tier1 },
 			]},
 			{"lvl_GrandmaGardens", [
-				new EnemyData { type = EnemyType.SlimeMedGreen, name = "_E_Slime_med_GREEN Variant" },
-				new EnemyData { type = EnemyType.SlimeSmallGreen, name = "_E_Slime_small_GREEN Variant" },
-				new EnemyData { type = EnemyType.SlimeBigGreen, name = "_E_Slime_big_GREEN Variant" },
-				new EnemyData { type = EnemyType.PotMimicAvariceExplode, name = "POT_Mimic_Explode_AVARICE Variant" },
-				new EnemyData { type = EnemyType.PotMimicAvariceMagic, name = "POT_Mimic_Magic_AVARICE Variant" },
-				new EnemyData { type = EnemyType.PotMimicAvariceMelee, name = "POT_Mimic_Melee_AVARICE Variant" },
+				new EnemyData { type = EnemyType.SlimeMedGreen, name = "_E_Slime_med_GREEN Variant", weightTier = EnemyData.WeightTier.Tier2 },
+				new EnemyData { type = EnemyType.SlimeSmallGreen, name = "_E_Slime_small_GREEN Variant", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.SlimeBigGreen, name = "_E_Slime_big_GREEN Variant", weightTier = EnemyData.WeightTier.Tier4 },
+				new EnemyData { type = EnemyType.PotMimicAvariceExplode, name = "POT_Mimic_Explode_AVARICE Variant", weightTier = EnemyData.WeightTier.Tier2 },
+				new EnemyData { type = EnemyType.PotMimicAvariceMagic, name = "POT_Mimic_Magic_AVARICE Variant", weightTier = EnemyData.WeightTier.Tier2 },
+				new EnemyData { type = EnemyType.PotMimicAvariceMelee, name = "POT_Mimic_Melee_AVARICE Variant", weightTier = EnemyData.WeightTier.Tier2 },
 			]},
 			{"lvl_GrandmaMansion", [
-				new EnemyData { type = EnemyType.PotMimicMagic, name = "POT_Mimic_Magic" },
-				new EnemyData { type = EnemyType.PotMimicExplode, name = "POT_Mimic_Explode" },
-				new EnemyData { type = EnemyType.PotMimicMelee, name = "POT_Mimic_Melee" },
+				new EnemyData { type = EnemyType.PotMimicMagic, name = "POT_Mimic_Magic", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.PotMimicExplode, name = "POT_Mimic_Explode", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.PotMimicMelee, name = "POT_Mimic_Melee", weightTier = EnemyData.WeightTier.Tier1 },
 			]},
 			{"lvl_Swamp", [
-				new EnemyData { type = EnemyType.FireplantNoHookshot, name = "_E_FIREPLANT_Nohookshot" },
-				new EnemyData { type = EnemyType.GhoulLongRange, name = "_E_GHOUL_LongRange Variant" },
-				new EnemyData { type = EnemyType.Grunt, name = "_E_GRUNT" },
-				new EnemyData { type = EnemyType.MagePlague, name = "_E_MAGE_Plague Variant" },
+				new EnemyData { type = EnemyType.FireplantNoHookshot, name = "_E_FIREPLANT_Nohookshot", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.GhoulLongRange, name = "_E_GHOUL_LongRange Variant", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.Grunt, name = "_E_GRUNT", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.MagePlague, name = "_E_MAGE_Plague Variant", weightTier = EnemyData.WeightTier.Tier3 },
 			]},
 			{"lvl_mountaintops", [
-				new EnemyData { type = EnemyType.Brute, name = "_E_BRUTE" },
-				new EnemyData { type = EnemyType.Fireplant, name = "_E_FIREPLANT" },
-				new EnemyData { type = EnemyType.MageGrounded, name = "_E_MAGE_Grounded Variant" },
+				new EnemyData { type = EnemyType.Brute, name = "_E_BRUTE", weightTier = EnemyData.WeightTier.Tier2 },
+				new EnemyData { type = EnemyType.Fireplant, name = "_E_FIREPLANT", weightTier = EnemyData.WeightTier.Tier1 },
 			]},
 			{"AVARICE_WAVES_Fortress", [
-				new EnemyData { type = EnemyType.SlimeSmall, name = "_E_Slime_small" },
-				new EnemyData { type = EnemyType.Jumper, name = "_E_JUMPER" },
-				new EnemyData { type = EnemyType.SlimeMed, name = "_E_Slime_med" },
-				new EnemyData { type = EnemyType.MageFire, name = "_E_MAGE_Fire Variant" },
-				new EnemyData { type = EnemyType.GruntYeti, name = "_E_GRUNT_Yeti Variant" },
+				new EnemyData { type = EnemyType.SlimeSmall, name = "_E_Slime_small", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.Jumper, name = "_E_JUMPER", weightTier = EnemyData.WeightTier.Tier3 },
+				new EnemyData { type = EnemyType.SlimeMed, name = "_E_Slime_med", weightTier = EnemyData.WeightTier.Tier2 },
+				new EnemyData { type = EnemyType.GruntYeti, name = "_E_GRUNT_Yeti Variant", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.MageFire, name = "_E_MAGE_Fire Variant", weightTier = EnemyData.WeightTier.Tier2 },
 			]},
 			{"lvl_SailorMountain", [
-				new EnemyData { type = EnemyType.PlagueKnightSlowFire, name = "_E_PLAGUE_KNIGHT_SlowFire" },
+				new EnemyData { type = EnemyType.PlagueKnightSlowFire, name = "_E_PLAGUE_KNIGHT_SlowFire", weightTier = EnemyData.WeightTier.Tier2 },
 			]},
 			{"lvl_GrandmaBasement", [
-				new EnemyData { type = EnemyType.SlimeBig, name = "_E_Slime_big" },
-				new EnemyData { type = EnemyType.Headroller, name = "_E_HEADROLLER" },
-				new EnemyData { type = EnemyType.PlagueKnight, name = "_E_PLAGUE_KNIGHT" },
+				new EnemyData { type = EnemyType.SlimeBig, name = "_E_Slime_big", weightTier = EnemyData.WeightTier.Tier3 },
+				new EnemyData { type = EnemyType.Headroller, name = "_E_HEADROLLER", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.PlagueKnight, name = "_E_PLAGUE_KNIGHT", weightTier = EnemyData.WeightTier.Tier2 },
 			]},
 			{"TEST_AREA", [
-				new EnemyData { type = EnemyType.Mage, name = "_E_MAGE" },
-				new EnemyData { type = EnemyType.GruntPot, name = "_E_GRUNT_Pot Variant" },
-				new EnemyData { type = EnemyType.GrimaceKnight, name = "_E_GRIMACE_KNIGHT" },
-				new EnemyData { type = EnemyType.Dodger, name = "_E_DODGER" },
-				new EnemyData { type = EnemyType.KnightGreenPlague, name = "_E_KNIGHT_GreenPlague" },
-				new EnemyData { type = EnemyType.Ghoul, name = "_E_GHOUL" },
+				new EnemyData { type = EnemyType.Mage, name = "_E_MAGE", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.GruntPot, name = "_E_GRUNT_Pot Variant", weightTier = EnemyData.WeightTier.Tier1 },
+				new EnemyData { type = EnemyType.GrimaceKnight, name = "_E_GRIMACE_KNIGHT", weightTier = EnemyData.WeightTier.Tier4 },
+				new EnemyData { type = EnemyType.Dodger, name = "_E_DODGER", weightTier = EnemyData.WeightTier.Tier3 },
+				new EnemyData { type = EnemyType.KnightGreenPlague, name = "_E_KNIGHT_GreenPlague", weightTier = EnemyData.WeightTier.Tier5 },
+				new EnemyData { type = EnemyType.Ghoul, name = "_E_GHOUL", weightTier = EnemyData.WeightTier.Tier1 },
 			]},
 			{"lvl_SilentServant_Fight", [
-				new EnemyData { type = EnemyType.ServantAll, name = "_E_SERVANT_All" },
-				new EnemyData { type = EnemyType.ServantBomb, name = "_E_SERVANT_Bombs" },
-				new EnemyData { type = EnemyType.ServantFire, name = "_E_SERVANT_FIRE Variant" },
-				new EnemyData { type = EnemyType.ServantHookshot, name = "_E_SERVANT_Hookshot Variant" },
+				new EnemyData { type = EnemyType.ServantAll, name = "_E_SERVANT_All", weightTier = EnemyData.WeightTier.Tier5 },
+				new EnemyData { type = EnemyType.ServantBomb, name = "_E_SERVANT_Bombs", weightTier = EnemyData.WeightTier.Tier5 },
+				new EnemyData { type = EnemyType.ServantFire, name = "_E_SERVANT_FIRE Variant", weightTier = EnemyData.WeightTier.Tier5 },
+				new EnemyData { type = EnemyType.ServantHookshot, name = "_E_SERVANT_Hookshot Variant", weightTier = EnemyData.WeightTier.Tier5 },
 			]},
 			{"boss_Frog", [
-				new EnemyData { type = EnemyType.GruntFrog, name = "_E_GRUNT_Frog" },
+				new EnemyData { type = EnemyType.GruntFrog, name = "_E_GRUNT_Frog", weightTier = EnemyData.WeightTier.Tier1 },
 			]},
 		};
 		enemiesToNotReplace = new()
@@ -190,7 +189,7 @@ internal class EnemyRandomizer : MonoBehaviour
 
 	private void OnEnable()
 	{
-		Logger.Log("EnemyType randomizer started!");
+		Logger.Log("Enemy randomizer started!");
 
 		// Preload enemies
 		foreach (var kvp in enemiesToCache)
@@ -212,6 +211,13 @@ internal class EnemyRandomizer : MonoBehaviour
 						{
 							foundEnemy = brain.gameObject;
 							foundEnemy.SetActive(true);
+
+							// If MageFire, cache the fire column pool so it can attack
+							if (enemyData.type == EnemyType.MageFire)
+							{
+								GameObject fireColumnPool = GameObject.Find("_FIRE_COLUMN_POOL");
+								Preloader.CacheObject(fireColumnPool);
+							}
 
 							// Modify silent servants
 							if (foundEnemy.TryGetComponent(out AI_SilentServant ai))
@@ -260,6 +266,7 @@ internal class EnemyRandomizer : MonoBehaviour
 	//	if (Input.GetKeyDown("t"))
 	//	{
 	//		SpawnEnemyAtPlayer((EnemyType)index);
+	//		Logger.Log($"Spawned enemy: {(EnemyType)index}");
 	//		index++;
 	//	}
 	//}
@@ -271,6 +278,7 @@ internal class EnemyRandomizer : MonoBehaviour
 
 	private void SceneLoaded(Scene scene, LoadSceneMode _)
 	{
+		hasSpawnedFireColumn = false;
 		ReplaceEnemiesInScene();
 	}
 
@@ -278,9 +286,9 @@ internal class EnemyRandomizer : MonoBehaviour
 	{
 		Transform player = PlayerGlobal.instance.transform;
 		Vector3 position = player.position - player.forward * 2f;
-		GameObject enemy = Instantiate(GetEnemy(enemyType));
-		enemy.transform.position = position;
-		return enemy;
+		GameObject newEnemy = Instantiate(GetEnemy(enemyType));
+		newEnemy.transform.position = position;
+		return newEnemy;
 	}
 
 	private void ReplaceEnemiesInScene()
@@ -360,16 +368,42 @@ internal class EnemyRandomizer : MonoBehaviour
 
 	private GameObject GetRandomEnemy()
 	{
-		EnemyType[] types = enemyTypeLookup.Keys.ToArray();
-		int randomIndex = Random.Range(0, types.Length);
-		EnemyType randomEnemy = types[randomIndex];
-		return GetEnemy(randomEnemy);
+		List<EnemyData> enemies = enemyTypeLookup.Values.ToList();
+		int totalWeight = enemies.Sum(e => e.GetWeight());
+		int roll = Random.Range(0, totalWeight);
+		int cumulative = 0;
+
+		foreach (EnemyData enemy in enemies)
+		{
+			cumulative += enemy.GetWeight();
+
+			if (roll < cumulative)
+			{
+				// If MageFire, instantiate the fire column pool so it can attack
+				if (!hasSpawnedFireColumn && enemy.type == EnemyType.MageFire)
+				{
+					Instantiate(Preloader.GetCachedObject<GameObject>("_FIRE_COLUMN_POOL"));
+					hasSpawnedFireColumn = true;
+				}
+
+				return Preloader.GetCachedObject<GameObject>(enemy.name);
+			}
+		}
+
+		return null;
 	}
 
 	private GameObject GetEnemy(EnemyType enemyType)
 	{
 		if (enemyTypeLookup.TryGetValue(enemyType, out EnemyData data))
 		{
+			// If MageFire, instantiate the fire column pool so it can attack
+			if (!hasSpawnedFireColumn && enemyType == EnemyType.MageFire)
+			{
+				Instantiate(Preloader.GetCachedObject<GameObject>("_FIRE_COLUMN_POOL"));
+				hasSpawnedFireColumn = true;
+			}
+
 			return Preloader.GetCachedObject<GameObject>(data.name);
 		}
 
@@ -387,6 +421,27 @@ internal class EnemyRandomizer : MonoBehaviour
 	{
 		public EnemyType type;
 		public string name;
+		public WeightTier weightTier;
+		/// <summary>
+		/// Set this greater than 0 to set a custom weight for this enemy
+		/// </summary>
+		public int weight = -1;
+
+		public EnemyData() { }
+
+		public int GetWeight()
+		{
+			return weight > 0 ? weight : (int)weightTier;
+		}
+
+		public enum WeightTier
+		{
+			Tier1 = 50,
+			Tier2 = 30,
+			Tier3 = 15,
+			Tier4 = 5,
+			Tier5 = 1,
+		}
 	}
 
 	[HarmonyPatch]

--- a/ArchipelagoRandomizer/EnemyRandomizer.cs
+++ b/ArchipelagoRandomizer/EnemyRandomizer.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -144,6 +143,7 @@ internal class EnemyRandomizer : MonoBehaviour
 	{
 		Logger.Log("Enemy randomizer started!");
 
+		// Preload enemies
 		foreach (var kvp in enemiesToCache)
 		{
 			string sceneName = kvp.Key;
@@ -208,7 +208,6 @@ internal class EnemyRandomizer : MonoBehaviour
 
 	public GameObject SpawnEnemyAtPlayer(Enemy enemyType)
 	{
-		Logger.LogError("test");
 		Transform player = PlayerGlobal.instance.transform;
 		Vector3 position = player.position - player.forward * 2f;
 		GameObject enemy = Instantiate(GetEnemy(enemyType));

--- a/ArchipelagoRandomizer/EnemyRandomizer.cs
+++ b/ArchipelagoRandomizer/EnemyRandomizer.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using static DDoor.ArchipelagoRandomizer.EnemyRandomizer;
 using Random = UnityEngine.Random;
 
 namespace DDoor.ArchipelagoRandomizer;
@@ -188,13 +189,9 @@ internal class EnemyRandomizer : MonoBehaviour
 				if (!enemyTypeLookup.ContainsKey(data.type))
 				{
 					enemyTypeLookup.Add(data.type, data);
+					enemyTypeEnabled[data.type] = Plugin.Instance.Config.Bind("Enemy Randomizer", data.type.ToString(), true, $"Enable enemy {data.type}");
 				}
 			}
-		}
-		foreach (EnemyType enemyType in enemyTypeLookup.Keys)
-		{
-			EnemyData data = enemyTypeLookup[enemyType];
-			enemyTypeEnabled[enemyType] = Plugin.Instance.Config.Bind("Enemy Randomizer", data.type.ToString(), true, $"Enable enemy {data.type}");
 		}
 	}
 

--- a/ArchipelagoRandomizer/EnemyRandomizer.cs
+++ b/ArchipelagoRandomizer/EnemyRandomizer.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using BepInEx.Configuration;
+using HarmonyLib;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -69,7 +70,8 @@ internal class EnemyRandomizer : MonoBehaviour
 	private static EnemyRandomizer instance;
 	private static readonly Array enemyValues = Enum.GetValues(typeof(EnemyType));
 	private Dictionary<string, EnemyData[]> enemiesToCache;
-	private Dictionary<EnemyType, EnemyData> enemyTypeLookup = new();
+	private readonly Dictionary<EnemyType, EnemyData> enemyTypeLookup = new();
+	private readonly Dictionary<EnemyType, ConfigEntry<bool>> enemyTypeEnabled = [];
 	private List<string> enemiesToNotReplace;
 	private bool hasSpawnedFireColumn;
 
@@ -182,8 +184,15 @@ internal class EnemyRandomizer : MonoBehaviour
 			foreach (EnemyData data in dataArr)
 			{
 				if (!enemyTypeLookup.ContainsKey(data.type))
+				{
 					enemyTypeLookup.Add(data.type, data);
+				}
 			}
+		}
+		foreach (EnemyType enemyType in enemyTypeLookup.Keys)
+		{
+			EnemyData data = enemyTypeLookup[enemyType];
+			enemyTypeEnabled[enemyType] = Plugin.Instance.Config.Bind("Enemy Randomizer", data.type.ToString(), true, $"Enable enemy {data.type}");
 		}
 	}
 
@@ -311,7 +320,7 @@ internal class EnemyRandomizer : MonoBehaviour
 						if (brain is AI_SilentServant)
 							break;
 
-						replacement = GetEnemyReplalcement(comp);
+						replacement = GetEnemyReplacement(comp);
 
 						if (replacement == null)
 							break;
@@ -324,7 +333,7 @@ internal class EnemyRandomizer : MonoBehaviour
 						break;
 					// Replace enemies that spawn from spawners
 					case WaveEnemy wave:
-						replacement = GetEnemyReplalcement(comp);
+						replacement = GetEnemyReplacement(comp);
 
 						if (replacement == null)
 							break;
@@ -333,7 +342,7 @@ internal class EnemyRandomizer : MonoBehaviour
 						break;
 					// Replace enemies that spawn from eggs (Lurkers)
 					case LurkerEgg egg:
-						replacement = GetEnemyReplalcement(comp);
+						replacement = GetEnemyReplacement(comp);
 
 						if (replacement == null)
 							break;
@@ -348,7 +357,7 @@ internal class EnemyRandomizer : MonoBehaviour
 		Logger.Log($"Took {sw.ElapsedMilliseconds}ms to replace all enemies in {scene.name}");
 	}
 
-	private GameObject GetEnemyReplalcement(Component comp)
+	private GameObject GetEnemyReplacement(Component comp)
 	{
 		string enemyName = comp switch
 		{
@@ -368,7 +377,7 @@ internal class EnemyRandomizer : MonoBehaviour
 
 	private GameObject GetRandomEnemy()
 	{
-		List<EnemyData> enemies = enemyTypeLookup.Values.ToList();
+		List<EnemyData> enemies = enemyTypeLookup.Values.Where(data => enemyTypeEnabled[data.type].Value == true).ToList();
 		int totalWeight = enemies.Sum(e => e.GetWeight());
 		int roll = Random.Range(0, totalWeight);
 		int cumulative = 0;
@@ -442,6 +451,7 @@ internal class EnemyRandomizer : MonoBehaviour
 			Tier4 = 5,
 			Tier5 = 1,
 		}
+
 	}
 
 	[HarmonyPatch]

--- a/ArchipelagoRandomizer/EnemyRandomizer.cs
+++ b/ArchipelagoRandomizer/EnemyRandomizer.cs
@@ -213,42 +213,34 @@ internal class EnemyRandomizer : MonoBehaviour
 
 				foreach (EnemyData enemyData in dataForEnemies)
 				{
-					GameObject foundEnemy = null;
-
-					foreach (AI_Brain brain in Resources.FindObjectsOfTypeAll<AI_Brain>())
-					{
-						if (brain.name == enemyData.name)
-						{
-							foundEnemy = brain.gameObject;
-							foundEnemy.SetActive(true);
-
-							// If MageFire, cache the fire column pool so it can attack
-							if (enemyData.type == EnemyType.MageFire)
-							{
-								GameObject fireColumnPool = GameObject.Find("_FIRE_COLUMN_POOL");
-								Preloader.CacheObject(fireColumnPool);
-							}
-
-							// Modify silent servants
-							if (foundEnemy.TryGetComponent(out AI_SilentServant ai))
-							{
-								DestroyImmediate(ai.GetComponentInChildren<CameraFocusObjectLimited>(true).gameObject);
-								ai.hasHookshot = false;
-
-								if (enemyData.type == EnemyType.ServantAll)
-								{
-									ai.hasAllPowers = false;
-									ai.hasBombs = true;
-									ai.hasFire = true;
-								}
-							}
-						}
-					}
+					GameObject foundEnemy = Resources.FindObjectsOfTypeAll<AI_Brain>().FirstOrDefault(x => x.name == enemyData.name)?.gameObject;
 
 					if (foundEnemy == null)
 					{
 						Logger.LogError($"During enemy rando preload, failed to find enemy\n    {enemyData.name}\n    in {sceneName}");
 						continue;
+					}
+
+					foundEnemy.SetActive(true);
+
+					// If MageFire, cache the fire column pool so it can attack
+					if (enemyData.type == EnemyType.MageFire)
+					{
+						Preloader.CacheObject(GameObject.Find("_FIRE_COLUMN_POOL"));
+					}
+
+					// Modify silent servants
+					if (foundEnemy.TryGetComponent(out AI_SilentServant ai))
+					{
+						DestroyImmediate(ai.GetComponentInChildren<CameraFocusObjectLimited>(true).gameObject);
+						ai.hasHookshot = false;
+
+						if (enemyData.type == EnemyType.ServantAll)
+						{
+							ai.hasAllPowers = false;
+							ai.hasBombs = true;
+							ai.hasFire = true;
+						}
 					}
 
 					enemies.Add(foundEnemy);
@@ -289,6 +281,8 @@ internal class EnemyRandomizer : MonoBehaviour
 
 	private void SceneLoaded(Scene scene, LoadSceneMode _)
 	{
+		if (SceneManager.GetActiveScene().name == "TitleScreen") return;
+
 		hasSpawnedFireColumn = false;
 		ReplaceEnemiesInScene();
 	}

--- a/ArchipelagoRandomizer/EnemyRandomizer.cs
+++ b/ArchipelagoRandomizer/EnemyRandomizer.cs
@@ -13,7 +13,7 @@ namespace DDoor.ArchipelagoRandomizer;
 
 internal class EnemyRandomizer : MonoBehaviour
 {
-	/* List of enemies that have been removed (kept as a reference in case they make a comeback
+	/* List of enemies that have been removed (kept as a reference in case they make a comeback)
 	 * 
 	 * _E_PLAGUE_KNIGHT_SlowFire
 	 *		Scene: lvl_SailorMountain
@@ -79,7 +79,6 @@ internal class EnemyRandomizer : MonoBehaviour
 	private readonly Dictionary<EnemyType, EnemyData> enemyTypeLookup = new();
 	private readonly Dictionary<EnemyType, ConfigEntry<bool>> enemyTypeEnabled = [];
 	private List<string> enemiesToNotReplaceOld;
-	//private Dictionary<string, Vector3> enemiesToNotReplace;
 	private List<NoReplaceData> enemiesToNotReplace;
 	private bool hasSpawnedFireColumn;
 
@@ -257,20 +256,6 @@ internal class EnemyRandomizer : MonoBehaviour
 		Preloader.Instance.OnPreloadDone -= AfterPreload;
 		SceneManager.sceneLoaded -= SceneLoaded;
 	}
-
-	//TODO: Remove this, as this is for quick testing before figuring out enemy replacements
-
-	//int index = 0;
-	//private void Update()
-	//{
-	//	if (Input.GetKeyDown("t"))
-	//	{
-	//		//SpawnEnemyAtPlayer((EnemyType)index);
-	//		//Logger.Log($"Spawned enemy: {(EnemyType)index}");
-	//		//SpawnEnemyAtPlayer(EnemyType.PlagueKnightSlowFire);
-	//		index++;
-	//	}
-	//}
 
 	private void AfterPreload()
 	{

--- a/ArchipelagoRandomizer/EnemyRandomizer.cs
+++ b/ArchipelagoRandomizer/EnemyRandomizer.cs
@@ -178,6 +178,7 @@ internal class EnemyRandomizer : MonoBehaviour
 			new NoReplaceData { scene = "boss_Grandma" },
 			new NoReplaceData { scene = "boss_Frog" },
 			new NoReplaceData { scene = "OldCrowVoid" },
+			new NoReplaceData { scene = "lvl_SilentServants" },
 		};
 
 		// Setup enemyType -> EnemyData lookup dict

--- a/ArchipelagoRandomizer/EntranceRandomizer.cs
+++ b/ArchipelagoRandomizer/EntranceRandomizer.cs
@@ -75,13 +75,22 @@ internal class EntranceRandomizer : MonoBehaviour
             if (Archipelago.Instance.IsConnected() && Instance != null && Instance.entranceRandomization)
             {
                 DoorTrigger doorTrigger = __instance.doorTrigger;
-                SceneTransitions.SceneTransition? newSceneTransition = SceneTransitions.GetConnectedSceneTransition(doorTrigger.doorId, doorTrigger.sceneToLoad);
-                doorTrigger.sceneToLoad = newSceneTransition?.toSceneName;
-                doorTrigger.targetDoor = newSceneTransition?.loadingZoneId;
+				
+				// Lord of Doors sequence's doors don't have triggers
+				if (doorTrigger != null)
+				{
+					SceneTransitions.SceneTransition? newSceneTransition = SceneTransitions.GetConnectedSceneTransition(doorTrigger.doorId, doorTrigger.sceneToLoad);
+
+					if (newSceneTransition != null)
+					{
+						doorTrigger.sceneToLoad = newSceneTransition?.toSceneName;
+						doorTrigger.targetDoor = newSceneTransition?.loadingZoneId;
+					}
+				}
             }
             if (!IC.ItemChangerPlugin.TryGetPlacedItem(typeof(IC.DoorLocation), __instance.keyId, out IC.Item? item))
             {
-                // If the door isn't randomized, don't disable it
+				// If the door isn't randomized, don't disable it
                 return;
             }
             string doorName = IC.Predefined.predefinedLocations.First(kvp => kvp.Value.GetType() == typeof(IC.DoorLocation) && ((IC.DoorLocation)kvp.Value).UniqueId == __instance.keyId).Key;

--- a/ArchipelagoRandomizer/Logger.cs
+++ b/ArchipelagoRandomizer/Logger.cs
@@ -1,4 +1,7 @@
-﻿namespace DDoor.ArchipelagoRandomizer;
+﻿using System;
+using System.Linq;
+
+namespace DDoor.ArchipelagoRandomizer;
 
 static class Logger
 {
@@ -12,8 +15,15 @@ static class Logger
 		Plugin.Logger.LogWarning(message);
 	}
 
-	public static void LogError(string message)
+	public static void LogError(string message, bool includeTrace = true)
 	{
-		Plugin.Logger.LogError(message);
+		Plugin.Logger.LogError(includeTrace ? message + "\n" + GetStackTrace() : message);
+	}
+
+	private static string GetStackTrace()
+	{
+		string stack = Environment.StackTrace;
+		string[] lines = stack.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+		return string.Join("\n", lines.Skip(3));
 	}
 }

--- a/ArchipelagoRandomizer/Logger.cs
+++ b/ArchipelagoRandomizer/Logger.cs
@@ -1,23 +1,22 @@
-﻿using System.Collections.Generic;
-
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace DDoor.ArchipelagoRandomizer;
 
-static class Logger
+public static class Logger
 {
-	public static void Log(string message)
+	public static void Log(object message)
 	{
 		Plugin.Logger.LogMessage(message);
 	}
 
-	public static void LogWarning(string message)
+	public static void LogWarning(object message)
 	{
 		Plugin.Logger.LogWarning(message);
 	}
 
-	public static void LogError(string message, bool includeTrace = true)
+	public static void LogError(object message, bool includeTrace = true)
 	{
 		Plugin.Logger.LogError(includeTrace ? message + "\n" + GetStackTrace() : message);
 	}

--- a/ArchipelagoRandomizer/MapManager.cs
+++ b/ArchipelagoRandomizer/MapManager.cs
@@ -66,6 +66,9 @@ public class MapManager : MonoBehaviour
 
     private void UpdateCoordsIfNeeded()
     {
+		if (Preloader.IsPreloading)
+			return;
+
         float currentTime = Time.time;
         PlayerCoords currentCoords = CurrentCoords();
         if (PlayerGlobal.instance)

--- a/ArchipelagoRandomizer/Plugin.cs
+++ b/ArchipelagoRandomizer/Plugin.cs
@@ -28,6 +28,15 @@ public class Plugin : BaseUnityPlugin
 	{
 		instance = this;
 
+		// Only show Unity logs that are errors
+		Application.logMessageReceivedThreaded += (condition, stackTrace, type) =>
+		{
+			if (type == LogType.Log || type == LogType.Warning)
+				return;
+
+			Logger.LogError($"{condition}\n{stackTrace}");
+		};
+
 		try
 		{
 			Logger = base.Logger;

--- a/ArchipelagoRandomizer/Plugin.cs
+++ b/ArchipelagoRandomizer/Plugin.cs
@@ -33,10 +33,7 @@ public class Plugin : BaseUnityPlugin
 			Logger = base.Logger;
 			Logger.LogInfo($"Plugin {MyPluginInfo.PLUGIN_GUID} is loaded!");
 
-			AGM.AlternativeGameModes.Add("ARCHIPELAGO", () =>
-			{
-				ArchipelagoRandomizerMod.Instance.OnFileCreated();
-			});
+			AGM.AlternativeGameModes.Add("ARCHIPELAGO", ArchipelagoRandomizerMod.Instance.OnFileCreated);
 
 			new Harmony("deathsdoor.archipelagorandomizer").PatchAll();
 			UIManager.Instance.AddOptionsMenuItems();
@@ -51,7 +48,6 @@ public class Plugin : BaseUnityPlugin
 		}
 	}
 
-	bool hasFaded;
 	private void Update()
 	{
 		OnUpdate?.Invoke();

--- a/ArchipelagoRandomizer/Plugin.cs
+++ b/ArchipelagoRandomizer/Plugin.cs
@@ -1,6 +1,8 @@
 ﻿using BepInEx;
 using BepInEx.Logging;
 using HarmonyLib;
+using System.Collections;
+using UnityEngine;
 using UnityEngine.Events;
 using AGM = DDoor.AlternativeGameModes;
 
@@ -49,9 +51,15 @@ public class Plugin : BaseUnityPlugin
 		}
 	}
 
+	bool hasFaded;
 	private void Update()
 	{
 		OnUpdate?.Invoke();
+	}
+
+	public static Coroutine StartRoutine(IEnumerator routine)
+	{
+		return Instance.StartCoroutine(routine);
 	}
 }
 

--- a/ArchipelagoRandomizer/Plugin.cs
+++ b/ArchipelagoRandomizer/Plugin.cs
@@ -62,6 +62,11 @@ public class Plugin : BaseUnityPlugin
 		OnUpdate?.Invoke();
 	}
 
+	private void OnApplicationQuit()
+	{
+		Preloader.Instance.Dispose();
+	}
+
 	public static Coroutine StartRoutine(IEnumerator routine)
 	{
 		return Instance.StartCoroutine(routine);

--- a/ArchipelagoRandomizer/Preloader.cs
+++ b/ArchipelagoRandomizer/Preloader.cs
@@ -47,6 +47,13 @@ internal class Preloader : IDisposable
 		return null;
 	}
 
+	public static void CacheObject(GameObject obj)
+	{
+		GameObject newObj = Object.Instantiate(obj, Instance.cacheHolder);
+		newObj.name = newObj.name.Replace("(Clone)", "");
+		Instance.cachedObjects.Add(newObj);
+	}
+
 	public void AddObjectToCacheList(string scene, OnLoadedSceneFunc onLoadedSceneCallback)
 	{
 		// If the scene is already in the cache list, add the new callback to it

--- a/ArchipelagoRandomizer/Preloader.cs
+++ b/ArchipelagoRandomizer/Preloader.cs
@@ -207,5 +207,15 @@ internal class Preloader : IDisposable
 			Instance.objectsToCache.Clear();
 			Object.Destroy(Instance.cacheHolder.gameObject);
 		}
+
+		[HarmonyPrefix]
+		[HarmonyPatch(typeof(LevelSpawn), nameof(LevelSpawn.Awake))]
+		private static void PreLevelSpawnAwake(LevelSpawn __instance)
+		{
+			if (IsPreloading)
+			{
+				__instance.spawnInjuredFalling = false;
+			}
+		}
 	}
 }

--- a/ArchipelagoRandomizer/Preloader.cs
+++ b/ArchipelagoRandomizer/Preloader.cs
@@ -119,8 +119,8 @@ internal class Preloader : IDisposable
 			}
 
 			// Wait for scene to load
-			yield return SceneManager.LoadSceneAsync(sceneToLoad, LoadSceneMode.Additive);
 			Logger.Log($"Preloading scene {sceneToLoad}...");
+			yield return SceneManager.LoadSceneAsync(sceneToLoad, LoadSceneMode.Additive);
 			SceneManager.SetActiveScene(SceneManager.GetSceneByName(sceneToLoad));
 			GameSceneManager.currentScene = sceneToLoad;
 
@@ -176,6 +176,9 @@ internal class Preloader : IDisposable
 		GameSceneManager.DontSaveNext();
 		GameSceneManager.LoadScene(savedScene, false);
 		GameSceneManager.ReloadSaveOnLoad();
+
+		// Start playing the scene's audio
+		GameSceneManager.instance.didLoadPlayer();
 	}
 
 	public delegate Object[] OnLoadedSceneFunc();
@@ -193,6 +196,13 @@ internal class Preloader : IDisposable
 
 			__instance.useSaveFile();
 			return false;
+		}
+
+		[HarmonyPrefix]
+		[HarmonyPatch(typeof(GameRoom), nameof(GameRoom.init))]
+		private static bool FixGameRoomNullRef()
+		{
+			return !IsPreloading;
 		}
 
 		// When returning to title, it clears the cached objects list

--- a/ArchipelagoRandomizer/Preloader.cs
+++ b/ArchipelagoRandomizer/Preloader.cs
@@ -1,0 +1,174 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Object = UnityEngine.Object;
+
+namespace DDoor.ArchipelagoRandomizer;
+
+internal class Preloader
+{
+	private readonly static Preloader instance = new();
+	private readonly Dictionary<string, List<OnLoadedSceneFunc>> objectsToCache;
+	private readonly List<Object> cachedObjects;
+	private Transform cacheHolder;
+	private Stopwatch stopwatch;
+
+	public static Preloader Instance => instance;
+	public static bool IsPreloading { get; private set; }
+
+	private Preloader()
+	{
+		objectsToCache = [];
+		cachedObjects = [];
+	}
+
+	public static T GetCachedObject<T>(string objName) where T : Object
+	{
+		// Find the cached object
+		Object obj = Instance.cachedObjects.Find(x => x.name == objName)
+			?? throw new Exception($"No object with name {objName} was found in the cached list of objects.");
+
+		return (T)obj;
+	}
+
+	public void AddObjectToCacheList(string scene, OnLoadedSceneFunc onLoadedSceneCallback)
+	{
+		// If the scene is already in the cache list, add the new callback to it
+		if (objectsToCache.ContainsKey(scene))
+		{
+			if (objectsToCache[scene].Contains(onLoadedSceneCallback))
+				return;
+
+			objectsToCache[scene].Add(onLoadedSceneCallback);
+		}
+		// If the scene is not already in cache list, add the new scene
+		else
+		{
+			objectsToCache.Add(scene, [onLoadedSceneCallback]);
+		}
+	}
+
+	public void StartPreload(Action onDone = null)
+	{
+		IsPreloading = true;
+		Logger.Log("Starting preload...");
+
+		// Create the parent that will hold the cached objects
+		cacheHolder = new GameObject("Cached Objects").transform;
+		cacheHolder.gameObject.SetActive(false);
+
+		// Make cache holder object persistent
+		Object.DontDestroyOnLoad(cacheHolder);
+
+		Plugin.StartRoutine(PreloadAll(onDone));
+	}
+
+	private IEnumerator PreloadAll(Action onDone)
+	{
+		int loopCount = 0;
+		bool hasDoneFadeOut = false;
+
+		foreach (KeyValuePair<string, List<OnLoadedSceneFunc>> kvp in objectsToCache)
+		{
+			loopCount++;
+			string sceneToLoad = kvp.Key;
+			List<OnLoadedSceneFunc> objectsToCache = kvp.Value;
+			GameSceneManager.instance.loadOnFadeOut = false;
+
+			if (!hasDoneFadeOut)
+			{
+				stopwatch = Stopwatch.StartNew();
+
+				// Start fadeout
+				ScreenFade.instance.SetColor(Color.white, false);
+				ScreenFade.instance.FadeOut(1f, true, null);
+				ScreenFade.instance.LockFade();
+
+				yield return new WaitWhile(ScreenFade.instance.IsFadingOut);
+				yield return SceneManager.UnloadSceneAsync("TitleScreen");
+				hasDoneFadeOut = true;
+			}
+
+			// Wait for scene to load
+			yield return SceneManager.LoadSceneAsync(sceneToLoad, LoadSceneMode.Additive);
+			Logger.Log($"Preloading scene {sceneToLoad}...");
+			SceneManager.SetActiveScene(SceneManager.GetSceneByName(sceneToLoad));
+			GameSceneManager.currentScene = sceneToLoad;
+
+			CacheObjects(objectsToCache);
+
+			if (loopCount < this.objectsToCache.Count)
+			{
+				yield return SceneManager.UnloadSceneAsync(sceneToLoad);
+			}
+		}
+
+		PreloadFinished(onDone);
+	}
+
+	private void CacheObjects(List<OnLoadedSceneFunc> callbacks)
+	{
+		for (int i = 0; i < callbacks.Count; i++)
+		{
+			// Get the objects to cache from the callback
+			Object[] objs = callbacks[i]?.Invoke();
+
+			foreach (Object obj in objs)
+			{
+				GameObject gameObj = obj as GameObject;
+
+				// If object is a GameObject, change its parent so it persists
+				if (gameObj != null)
+					gameObj.transform.SetParent(cacheHolder, true);
+				else
+				{
+					Object.DontDestroyOnLoad(obj);
+				}
+
+				cachedObjects.Add(obj);
+			}
+		}
+	}
+
+	private void PreloadFinished(Action onDone)
+	{
+		stopwatch.Stop();
+		Logger.Log($"Finished preloading {cachedObjects.Count} object(s) across {objectsToCache.Count} scene(s) in {stopwatch.ElapsedMilliseconds}ms");
+		IsPreloading = false;
+		objectsToCache.Clear();
+		onDone?.Invoke();
+
+		GameSceneManager.DontSaveNext();
+		GameSceneManager.LoadScene(GameSave.GetSaveData().GetSpawnScene(), false);
+		GameSceneManager.ReloadSaveOnLoad();
+	}
+
+	public delegate Object[] OnLoadedSceneFunc();
+
+	[HarmonyPatch]
+	private class Patches
+	{
+		// Patches the new game press event to not immediately load into the saved scene. This will be done when preloading is finished.
+		[HarmonyPrefix]
+		[HarmonyPatch(typeof(SaveSlot), nameof(SaveSlot.LoadSave))]
+		private static bool NewGamePatch(SaveSlot __instance)
+		{
+			__instance.useSaveFile();
+			return false;
+		}
+
+		// When returning to title, it clears the cached objects list
+		[HarmonyPrefix]
+		[HarmonyPatch(typeof(GameSceneManager), nameof(GameSceneManager.ReturnToTitle))]
+		private static void ReturnToTitlePatch()
+		{
+			Instance.cachedObjects.Clear();
+			Instance.objectsToCache.Clear();
+			Object.Destroy(Instance.cacheHolder.gameObject);
+		}
+	}
+}

--- a/ArchipelagoRandomizer/Preloader.cs
+++ b/ArchipelagoRandomizer/Preloader.cs
@@ -9,7 +9,7 @@ using Object = UnityEngine.Object;
 
 namespace DDoor.ArchipelagoRandomizer;
 
-internal class Preloader
+internal class Preloader : IDisposable
 {
 	private readonly static Preloader instance = new();
 	private readonly Dictionary<string, List<OnLoadedSceneFunc>> objectsToCache;
@@ -17,6 +17,8 @@ internal class Preloader
 	private Transform cacheHolder;
 	private Stopwatch stopwatch;
 	private string savedScene;
+
+	public event Action OnPreloadDone;
 
 	public static Preloader Instance => instance;
 	public static bool IsPreloading { get; private set; }
@@ -76,6 +78,11 @@ internal class Preloader
 		Object.DontDestroyOnLoad(cacheHolder);
 
 		Plugin.StartRoutine(PreloadAll(onDone));
+	}
+
+	public void Dispose()
+	{
+		OnPreloadDone = null;
 	}
 
 	private IEnumerator PreloadAll(Action onDone)
@@ -157,6 +164,7 @@ internal class Preloader
 		IsPreloading = false;
 		objectsToCache.Clear();
 		onDone?.Invoke();
+		OnPreloadDone?.Invoke();
 
 		GameSceneManager.DontSaveNext();
 		GameSceneManager.LoadScene(savedScene, false);

--- a/ArchipelagoRandomizer/TrapManager.cs
+++ b/ArchipelagoRandomizer/TrapManager.cs
@@ -1,11 +1,11 @@
 using DDoor.AddUIToOptionsMenu;
-using DDoor.ItemChanger;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using UnityEngine.XR;
 
 namespace DDoor.ArchipelagoRandomizer;
 
@@ -36,12 +36,12 @@ public class TrapManager : MonoBehaviour
 
 	private void OnEnable()
 	{
-		SceneManager.activeSceneChanged += OnSceneChanged;
+		SceneManager.sceneLoaded += OnSceneChanged;
 	}
 
 	private void OnDisable()
 	{
-		SceneManager.activeSceneChanged -= OnSceneChanged;
+		SceneManager.sceneLoaded -= OnSceneChanged;
 	}
 
     private IEnumerator TrapHandler()
@@ -85,7 +85,7 @@ public class TrapManager : MonoBehaviour
         }
     }
 
-	private void OnSceneChanged(Scene _, Scene __)
+	private void OnSceneChanged(Scene _, LoadSceneMode __)
 	{
 		// Stop enemy invis coroutine
 		if (enemyInvisCoroutine != null)
@@ -132,9 +132,11 @@ public class TrapManager : MonoBehaviour
 		int enemyLayer = LayerMask.NameToLayer("Enemy");
 
 		// Get all active enemy meshes
-		List<SkinnedMeshRenderer> allEnemyMeshes = Resources.FindObjectsOfTypeAll<AI_Brain>()
+		List<SkinnedMeshRenderer> allEnemyMeshes = SceneManager.GetActiveScene()
+			.GetRootGameObjects()
+			.SelectMany(root => root.GetComponentsInChildren<AI_Brain>(true))
 			.Where(ai => ai.gameObject.layer == enemyLayer) // Checks for enemy layer
-			.SelectMany(ai => ai.GetComponentsInChildren<SkinnedMeshRenderer>()) // Gets all meshes (there can be many children with meshes)
+			.SelectMany(ai => ai.GetComponentsInChildren<SkinnedMeshRenderer>(true)) // Gets all meshes (there can be many children with meshes)
 			.Where(mesh => mesh.gameObject.activeSelf) // Gets only the active meshes
 			.ToList();
 

--- a/ArchipelagoRandomizer/UIManager.cs
+++ b/ArchipelagoRandomizer/UIManager.cs
@@ -40,6 +40,7 @@ internal class UIManager
 		AddDeathlinkToggle();
 		AddItemHandlingToggle();
 		AddCutsceneToggle();
+		AddEnemyRandoToggle();
 		IngameUIManager.RetriggerModifyingOptionsMenuTitleScreen();
 	}
 
@@ -58,6 +59,12 @@ internal class UIManager
 	private void AddCutsceneToggle()
 	{
 		OptionsToggle optionsToggle = new(itemText: "SKIP CUTSCENES", gameObjectName: "ARCHIPELAGO_UI_ToggleSkipCutscenes", id: "ToggleSkipCutscenes", relevantScenes: [IngameUIManager.RelevantScene.TitleScreen], toggleAction: Archipelago.Instance.ToggleSkipCutscenes, toggleValueInitializer: Archipelago.Instance.InitializeSkipCutscenes, contextText: "BUTTON:CONFIRM Toggle Skip Cutscenes BUTTON:BACK Back");
+		IngameUIManager.AddOptionsMenuItem(optionsToggle);
+	}
+
+	private void AddEnemyRandoToggle()
+	{
+		OptionsToggle optionsToggle = new(itemText: "ENEMY RANDOMIZER", gameObjectName: "ARCHIPELAGO_UI_ToggleEnnemyRando", id: "ToggleEnnemyRando", relevantScenes: [IngameUIManager.RelevantScene.TitleScreen], toggleAction: Archipelago.Instance.ToggleEnemyRando, toggleValueInitializer: Archipelago.Instance.InitializeEnemyRando, contextText: "BUTTON:CONFIRM Toggle Enemy Ranndomizer BUTTON:BACK Back");
 		IngameUIManager.AddOptionsMenuItem(optionsToggle);
 	}
 

--- a/DDArchipelagoRandomizer.csproj
+++ b/DDArchipelagoRandomizer.csproj
@@ -98,14 +98,6 @@
 	</Target>
 
 	<ItemGroup>
-	  <EditorConfigFiles Remove="D:\Files\Work\Hobbies\Modding\Death%27s Door\DDArchipelagoRandomizer\.editorconfig" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <None Include="D:\Files\Work\Hobbies\Modding\Death's Door\DDArchipelagoRandomizer\.editorconfig" />
-	</ItemGroup>
-
-	<ItemGroup>
 	  <None Update="Resources\Item Changer Icons\**">
 	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </None>

--- a/DDArchipelagoRandomizer.csproj
+++ b/DDArchipelagoRandomizer.csproj
@@ -5,7 +5,7 @@
 		<AssemblyTitle>Archipelago Randomizer</AssemblyTitle>
 		<Product>ArchipelagoRandomizer</Product>
 		<Description>An Archipelago multiworld client for Death's Door</Description>
-		<Version>0.2.1</Version>
+		<Version>0.3.3</Version>
 		<TargetFramework>net472</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<RestoreAdditionalProjectSources>


### PR DESCRIPTION
Draft PR. This is a work in progress and I'll request review once it's done.

The idea for the first version of enemy rando is it will only randomize common enemies and not bosses. I _would_ like the option later to allow randomizing bosses too, but that I imagine will require a lot more work.

This also introduces `Preloader`, which is a utility class to cache any number of objects across scenes.