### PR TITLE
Entrance Randomization

### DIFF
--- a/ArchipelagoRandomizer/Archipelago.cs
+++ b/ArchipelagoRandomizer/Archipelago.cs
@@ -322,6 +322,7 @@ internal class Archipelago
 		string forPlayer = itemInfo.Player.Name;
 		bool isForAnotherPlayer = itemInfo.Player != CurrentPlayer;
 		return new ItemRandomizer.ItemPlacement(item, location, forPlayer, isForAnotherPlayer);
+
 	}
 
 	private bool CanPlayerReceiveItems()
@@ -349,6 +350,29 @@ internal class Archipelago
             return;
         }
 		Session.DataStorage[$"{Session.ConnectionInfo.Slot}_{Session.ConnectionInfo.Team}_deathsdoor_map"] = map;
+    }
+
+	internal void StoreFoundEntrance(string newEntrance)
+    {
+		// Retrieves existing found entrances from DataStorage for same slot co-op, restarting save files, etc.
+		if (!IsConnected())
+		{
+			return;
+		}
+		JArray foundEntrances;
+		if (Session.DataStorage[$"{Session.ConnectionInfo.Slot}_{Session.ConnectionInfo.Team}_deathsdoor_found_entrances"] != null)
+		{
+			foundEntrances = Session.DataStorage[$"{Session.ConnectionInfo.Slot}_{Session.ConnectionInfo.Team}_deathsdoor_found_entrances"];
+		}
+		else
+		{
+			foundEntrances = JArray.FromObject(new List<string>());
+		}
+		if (!foundEntrances.Any(e => e.Value<string>() == newEntrance))
+		{
+			foundEntrances.Add(newEntrance);
+			Session.DataStorage[$"{Session.ConnectionInfo.Slot}_{Session.ConnectionInfo.Team}_deathsdoor_found_entrances"] = JArray.FromObject(foundEntrances);
+		}		
     }
 
 	internal void ToggleDeathlink(bool newValue)

--- a/ArchipelagoRandomizer/ArchipelagoRandomizerMod.cs
+++ b/ArchipelagoRandomizer/ArchipelagoRandomizerMod.cs
@@ -1,8 +1,6 @@
-﻿using HarmonyLib;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.SceneManagement;
 using static DDoor.ArchipelagoRandomizer.Archipelago;
-using AGM = DDoor.AlternativeGameModes;
 
 namespace DDoor.ArchipelagoRandomizer;
 
@@ -69,6 +67,7 @@ internal class ArchipelagoRandomizerMod
 			{
 				archipelagoRandomizer = new GameObject("ArchipelagoRandomizer");
 				ItemRandomizer itemRando = archipelagoRandomizer.AddComponent<ItemRandomizer>();
+				EntranceRandomizer entranceRandomizer = archipelagoRandomizer.AddComponent<EntranceRandomizer>();
 				GoalModifications goalMods = archipelagoRandomizer.AddComponent<GoalModifications>();
 				MapManager mapManager = archipelagoRandomizer.AddComponent<MapManager>();
 				TrapManager trapManager = archipelagoRandomizer.AddComponent<TrapManager>();

--- a/ArchipelagoRandomizer/ComponentUtil.cs
+++ b/ArchipelagoRandomizer/ComponentUtil.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace DDoor.ArchipelagoRandomizer;
+
+public static class ComponentUtil
+{
+    public static List<T> FindAllComponentsOfTypeInScene<T>(string parentScene)
+    {
+        Scene activeScene = SceneManager.GetSceneByName(parentScene);
+        GameObject[] rootObjects = activeScene.GetRootGameObjects();
+        List<T> allComponents = [];
+        for (int i = 0; i < rootObjects.Count(); i++)
+        {
+            allComponents.AddRange([.. rootObjects[i].GetComponentsInChildren<T>(true)]);
+        }
+        return allComponents;
+    }
+}

--- a/ArchipelagoRandomizer/CutsceneFlags.cs
+++ b/ArchipelagoRandomizer/CutsceneFlags.cs
@@ -1,5 +1,6 @@
 using DDoor.AddUIToOptionsMenu;
 using HarmonyLib;
+using System.Diagnostics;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -82,12 +83,6 @@ public static class CutsceneFlags
                 }
                 skippedCutscenes = true;
             }
-        }
-
-        [HarmonyPrefix, HarmonyPatch(typeof(GameSave), nameof(GameSave.SetKeyState))]
-        private static void ReportKey(string id)
-        {
-            Plugin.Logger.LogInfo("Key Set in Save: " + id);
         }
     }
 }

--- a/ArchipelagoRandomizer/Data/SceneTransitions.json
+++ b/ArchipelagoRandomizer/Data/SceneTransitions.json
@@ -1,0 +1,457 @@
+[
+    {
+        "startingRegion": "Door to Grove of Spirits",
+        "endingRegion": "Grove of Spirits Door",
+        "loadingZoneId": "sdoor_tutorial",
+        "toSceneName": "lvl_Tutorial",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "Grove of Spirits Door",
+        "endingRegion": "Door to Grove of Spirits",
+        "loadingZoneId": "sdoor_tutorial",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "lvl_Tutorial"
+    },
+    {
+        "startingRegion": "Door to Lost Cemetery",
+        "endingRegion": "Lost Cemetery Door",
+        "loadingZoneId": "sdoor_graveyard",
+        "toSceneName": "lvl_Graveyard",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "Lost Cemetery Door",
+        "endingRegion": "Door to Lost Cemetery",
+        "loadingZoneId": "sdoor_graveyard",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "lvl_Graveyard"
+    },
+    {
+        "startingRegion": "Door to Estate of the Urn Witch",
+        "endingRegion": "Estate of the Urn Witch Door",
+        "loadingZoneId": "sdoor_gardens",
+        "toSceneName": "lvl_GrandmaGardens",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "Estate of the Urn Witch Door",
+        "endingRegion": "Door to Estate of the Urn Witch",
+        "loadingZoneId": "sdoor_gardens",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "lvl_GrandmaGardens"
+    },
+    {
+        "startingRegion": "Door to Ceramic Manor",
+        "endingRegion": "Ceramic Manor Door",
+        "loadingZoneId": "sdoor_mansion",
+        "toSceneName": "lvl_GrandmaMansion",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "Ceramic Manor Door",
+        "endingRegion": "Door to Ceramic Manor",
+        "loadingZoneId": "sdoor_mansion",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "lvl_GrandmaMansion"
+    },
+    {
+        "startingRegion": "Door to Inner Furnace",
+        "endingRegion": "Inner Furnace Door",
+        "loadingZoneId": "sdoor_basementromp",
+        "toSceneName": "lvl_GrandmaBasement",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "Inner Furnace Door",
+        "endingRegion": "Door to Inner Furnace",
+        "loadingZoneId": "sdoor_basementromp",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "lvl_GrandmaBasement"
+    },
+    {
+        "startingRegion": "Door to the Urn Witch's Laboratory",
+        "endingRegion": "The Urn Witch's Laboratory Door",
+        "loadingZoneId": "sdoor_grandmaboss",
+        "toSceneName": "boss_grandma",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "The Urn Witch's Laboratory Door",
+        "endingRegion": "Door to the Urn Witch's Laboratory",
+        "loadingZoneId": "sdoor_grandmaboss",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "boss_grandma"
+    },
+    {
+        "startingRegion": "Door to Overgrown Ruins",
+        "endingRegion": "Overgrown Ruins Door",
+        "loadingZoneId": "sdoor_forest",
+        "toSceneName": "lvl_Forest",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "Overgrown Ruins Door",
+        "endingRegion": "Door to Overgrown Ruins",
+        "loadingZoneId": "sdoor_forest",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "lvl_Forest"
+    },
+    {
+        "startingRegion": "Door to Mushroom Dungeon",
+        "endingRegion": "Mushroom Dungeon Door",
+        "loadingZoneId": "sdoor_forest_dung",
+        "toSceneName": "lvl_Forest",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "Mushroom Dungeon Door",
+        "endingRegion": "Door to Mushroom Dungeon",
+        "loadingZoneId": "sdoor_forest_dung",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "lvl_Forest"
+    },
+    {
+        "startingRegion": "Door to Flooded Fortress",
+        "endingRegion": "Flooded Fortress Door",
+        "loadingZoneId": "sdoor_swamp",
+        "toSceneName": "lvl_Swamp",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "Flooded Fortress Door",
+        "endingRegion": "Door to Flooded Fortress",
+        "loadingZoneId": "sdoor_swamp",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "lvl_Swamp"
+    },
+    {
+        "startingRegion": "Door to Throne of the Frog King",
+        "endingRegion": "Throne of the Frog King Door",
+        "loadingZoneId": "sdoor_frogboss",
+        "toSceneName": "boss_frog",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "Throne of the Frog King Door",
+        "endingRegion": "Door to Throne of the Frog King",
+        "loadingZoneId": "sdoor_frogboss",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "boss_frog"
+    },
+    {
+        "startingRegion": "Door to Stranded Sailor",
+        "endingRegion": "Stranded Sailor Door",
+        "loadingZoneId": "sdoor_sailor",
+        "toSceneName": "lvl_SailorMountain",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "Stranded Sailor Door",
+        "endingRegion": "Door to Stranded Sailor",
+        "loadingZoneId": "sdoor_sailor",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "lvl_SailorMountain"
+    },
+    {
+        "startingRegion": "Door to Castle Lockstone",
+        "endingRegion": "Castle Lockstone Door",
+        "loadingZoneId": "sdoor_fortress",
+        "toSceneName": "lvl_frozenfortress",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "Castle Lockstone Door",
+        "endingRegion": "Door to Castle Lockstone",
+        "loadingZoneId": "sdoor_fortress",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "lvl_frozenfortress"
+    },
+    {
+        "startingRegion": "Door to Camp of the Free Crows",
+        "endingRegion": "Camp of the Free Crows Door",
+        "loadingZoneId": "sdoor_covenant",
+        "toSceneName": "lvlConnect_Fortress_Mountaintops",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "Camp of the Free Crows Door",
+        "endingRegion": "Door to Camp of the Free Crows",
+        "loadingZoneId": "sdoor_covenant",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "lvlConnect_Fortress_Mountaintops"
+    },
+    {
+        "startingRegion": "Door to Old Watchtowers",
+        "endingRegion": "Old Watchtowers Door",
+        "loadingZoneId": "sdoor_mountaintops",
+        "toSceneName": "lvl_Mountaintops",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "Old Watchtowers Door",
+        "endingRegion": "Door to Old Watchtowers",
+        "loadingZoneId": "sdoor_mountaintops",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "lvl_Mountaintops"
+    },
+    {
+        "startingRegion": "Door to Betty's Lair",
+        "endingRegion": "Betty's Lair Door",
+        "loadingZoneId": "sdoor_betty",
+        "toSceneName": "boss_betty",
+        "originSceneName": "lvl_HallOfDoors"
+    },
+    {
+        "startingRegion": "Betty's Lair Door",
+        "endingRegion": "Door to Betty's Lair",
+        "loadingZoneId": "sdoor_betty",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": "boss_betty"
+    },
+    {
+        "startingRegion": "Grove of Spirits Exit to Lost Cemetery",
+        "endingRegion": "Lost Cemetery Exit to Grove of Spirits",
+        "loadingZoneId": "tdoor_gy",
+        "toSceneName": "lvl_Graveyard",
+        "originSceneName": "lvl_Tutorial"
+    },
+    {
+        "startingRegion": "Lost Cemetery Exit to Grove of Spirits",
+        "endingRegion": "Grove of Spirits Exit to Lost Cemetery",
+        "loadingZoneId": "tdoor_gy",
+        "toSceneName": "lvl_Tutorial",
+        "originSceneName": "lvl_Graveyard"
+    },
+    {
+        "startingRegion": "Lost Cemetery Exit to Crypt",
+        "endingRegion": "Crypt Exit to Lost Cemetery",
+        "loadingZoneId": "d_graveyardtocrypt",
+        "toSceneName": "lvlConnect_Graveyard_Gardens",
+        "originSceneName": "lvl_Graveyard"
+    },
+    {
+        "startingRegion": "Crypt Exit to Lost Cemetery",
+        "endingRegion": "Lost Cemetery Exit to Crypt",
+        "loadingZoneId": "d_graveyardtocrypt",
+        "toSceneName": "lvl_Graveyard",
+        "originSceneName": "lvlConnect_Graveyard_Gardens"
+    },
+    {
+        "startingRegion": "Crypt Exit to Estate of the Urn Witch",
+        "endingRegion": "Estate of the Urn Witch Exit to Crypt",
+        "loadingZoneId": "d_crypttogardens",
+        "toSceneName": "lvl_GrandmaGardens",
+        "originSceneName": "lvlConnect_Graveyard_Gardens"
+    },
+    {
+        "startingRegion": "Estate of the Urn Witch Exit to Crypt",
+        "endingRegion": "Crypt Exit to Estate of the Urn Witch",
+        "loadingZoneId": "d_crypttogardens",
+        "toSceneName": "lvlConnect_Graveyard_Gardens",
+        "originSceneName": "lvl_GrandmaGardens"
+    },
+    {
+        "startingRegion": "Estate of the Urn Witch Exit to Ceramic Manor",
+        "endingRegion": "Ceramic Manor Exit to Estate of the Urn Witch",
+        "loadingZoneId": "d_gardenstomansion",
+        "toSceneName": "lvl_GrandmaMansion",
+        "originSceneName": "lvl_GrandmaGardens"
+    },
+    {
+        "startingRegion": "Ceramic Manor Exit to Estate of the Urn Witch",
+        "endingRegion": "Estate of the Urn Witch Exit to Ceramic Manor",
+        "loadingZoneId": "d_gardenstomansion",
+        "toSceneName": "lvl_GrandmaGardens",
+        "originSceneName": "lvl_GrandmaMansion"
+    },
+    {
+        "startingRegion": "Ceramic Manor Exit to Furnace Observation Rooms",
+        "endingRegion": "Furnace Observation Rooms Exit to Ceramic Manor",
+        "loadingZoneId": "d_mansiontobasement",
+        "toSceneName": "lvlConnect_Mansion_Basement",
+        "originSceneName": "lvl_GrandmaMansion"
+    },
+    {
+        "startingRegion": "Furnace Observation Rooms Exit to Ceramic Manor",
+        "endingRegion": "Ceramic Manor Exit to Furnace Observation Rooms",
+        "loadingZoneId": "d_mansiontobasement",
+        "toSceneName": "lvl_GrandmaMansion",
+        "originSceneName": "lvlConnect_Mansion_Basement"
+    },
+    {
+        "startingRegion": "Furnace Observation Rooms Exit to Inner Furnace",
+        "endingRegion": "Inner Furnace Exit to Furnace Observation Rooms",
+        "loadingZoneId": "d_basementtoromp",
+        "toSceneName": "lvl_GrandmaBasement",
+        "originSceneName": "lvlConnect_Mansion_Basement"
+    },
+    {
+        "startingRegion": "Inner Furnace Exit to Furnace Observation Rooms",
+        "endingRegion": "Furnace Observation Rooms Exit to Inner Furnace",
+        "loadingZoneId": "d_basementtoromp",
+        "toSceneName": "lvlConnect_Mansion_Basement",
+        "originSceneName": "lvl_GrandmaBasement"
+    },
+    {
+        "startingRegion": "Inner Furnace Exit to the Urn Witch's Laboratory",
+        "endingRegion": "The Urn Witch's Laboratory Exit to Inner Furnace",
+        "loadingZoneId": "d_basementtoboss",
+        "toSceneName": "boss_grandma",
+        "originSceneName": "lvl_GrandmaBasement"
+    },
+    {
+        "startingRegion": "The Urn Witch's Laboratory Exit to Inner Furnace",
+        "endingRegion": "Inner Furnace Exit to the Urn Witch's Laboratory",
+        "loadingZoneId": "d_basementtoboss",
+        "toSceneName": "lvl_GrandmaBasement",
+        "originSceneName": "boss_grandma"
+    },
+    {
+        "startingRegion": "Lost Cemetery Exit to Stranded Sailor Caves",
+        "endingRegion": "Stranded Sailor Caves Exit to Lost Cemetery",
+        "loadingZoneId": "d_graveyardtosailorcaves",
+        "toSceneName": "lvlconnect_graveyard_sailor",
+        "originSceneName": "lvl_graveyard"
+    },
+    {
+        "startingRegion": "Stranded Sailor Caves Exit to Lost Cemetery",
+        "endingRegion": "Lost Cemetery Exit to Stranded Sailor Caves",
+        "loadingZoneId": "d_graveyardtosailorcaves",
+        "toSceneName": "lvl_graveyard",
+        "originSceneName": "lvlconnect_graveyard_sailor"
+    },
+    {
+        "startingRegion": "Stranded Sailor Caves Exit to Stranded Sailor",
+        "endingRegion": "Stranded Sailor Exit to Stranded Sailor Caves",
+        "loadingZoneId": "d_connecttosailor",
+        "toSceneName": "lvl_sailormountain",
+        "originSceneName": "lvlconnect_graveyard_sailor"
+    },
+    {
+        "startingRegion": "Stranded Sailor Exit to Stranded Sailor Caves",
+        "endingRegion": "Stranded Sailor Caves Exit to Stranded Sailor",
+        "loadingZoneId": "d_connecttosailor",
+        "toSceneName": "lvlconnect_graveyard_sailor",
+        "originSceneName": "lvl_sailormountain"
+    },
+    {
+        "startingRegion": "Stranded Sailor Exit to Castle Lockstone",
+        "endingRegion": "Castle Lockstone Exit to Stranded Sailor",
+        "loadingZoneId": "d_sailortofortress",
+        "toSceneName": "lvl_frozenfortress",
+        "originSceneName": "lvl_sailormountain"
+    },
+    {
+        "startingRegion": "Castle Lockstone Exit to Stranded Sailor",
+        "endingRegion": "Stranded Sailor Exit to Castle Lockstone",
+        "loadingZoneId": "d_sailortofortress",
+        "toSceneName": "lvl_sailormountain",
+        "originSceneName": "lvl_frozenfortress"
+    },
+    {
+        "startingRegion": "Castle Lockstone Exit to Camp of the Free Crows",
+        "endingRegion": "Camp of the Free Crows Exit to Castle Lockstone",
+        "loadingZoneId": "d_fortresstoroof",
+        "toSceneName": "lvlConnect_Fortress_Mountaintops",
+        "originSceneName": "lvl_frozenfortress"
+    },
+    {
+        "startingRegion": "Camp of the Free Crows Exit to Castle Lockstone",
+        "endingRegion": "Castle Lockstone Exit to Camp of the Free Crows",
+        "loadingZoneId": "d_fortresstoroof",
+        "toSceneName": "lvl_frozenfortress",
+        "originSceneName": "lvlConnect_Fortress_Mountaintops"
+    },
+    {
+        "startingRegion": "Camp of the Free Crows Exit to Old Watchtowers",
+        "endingRegion": "Old Watchtowers Exit to Camp of the Free Crows",
+        "loadingZoneId": "d_CrowCavestoMountaintops",
+        "toSceneName": "lvl_mountaintops",
+        "originSceneName": "lvlConnect_Fortress_Mountaintops"
+    },
+    {
+        "startingRegion": "Old Watchtowers Exit to Camp of the Free Crows",
+        "endingRegion": "Camp of the Free Crows Exit to Old Watchtowers",
+        "loadingZoneId": "d_CrowCavestoMountaintops",
+        "toSceneName": "lvlConnect_Fortress_Mountaintops",
+        "originSceneName": "lvl_mountaintops"
+    },
+    {
+        "startingRegion": "Old Watchtowers Exit to Betty's Lair",
+        "endingRegion": "Betty's Lair Exit to Old Watchtowers",
+        "loadingZoneId": "d_mountaintopstobetty",
+        "toSceneName": "boss_betty",
+        "originSceneName": "lvl_mountaintops"
+    },
+    {
+        "startingRegion": "Betty's Lair Exit to Old Watchtowers",
+        "endingRegion": "Old Watchtowers Exit to Betty's Lair",
+        "loadingZoneId": "d_mountaintopstobetty",
+        "toSceneName": "lvl_mountaintops",
+        "originSceneName": "boss_betty"
+    },
+    {
+        "startingRegion": "Lost Cemetery Exit to Overgrown Ruins",
+        "endingRegion": "Overgrown Ruins Exit to Lost Cemetery",
+        "loadingZoneId": "forest_buggy",
+        "toSceneName": "lvl_Forest",
+        "originSceneName": "lvl_Graveyard"
+    },
+    {
+        "startingRegion": "Overgrown Ruins Exit to Lost Cemetery",
+        "endingRegion": "Lost Cemetery Exit to Overgrown Ruins",
+        "loadingZoneId": "forest_buggy",
+        "toSceneName": "lvl_Graveyard",
+        "originSceneName": "lvl_Forest"
+    },
+    {
+        "startingRegion": "Mushroom Dungeon Exit to Flooded Fortress",
+        "endingRegion": "Flooded Fortress Exit to Mushroom Dungeon",
+        "loadingZoneId": "d_swamp_enter",
+        "toSceneName": "lvl_Swamp",
+        "originSceneName": "lvl_Forest"
+    },
+    {
+        "startingRegion": "Flooded Fortress Exit to Mushroom Dungeon",
+        "endingRegion": "Mushroom Dungeon Exit to Flooded Fortress",
+        "loadingZoneId": "d_swamp_enter",
+        "toSceneName": "lvl_Forest",
+        "originSceneName": "lvl_Swamp"
+    },
+    {
+        "startingRegion": "Flooded Fortress Exit to Throne of the Frog King",
+        "endingRegion": "Throne of the Frog King Exit to Flooded Fortress",
+        "loadingZoneId": "d_frog_boss",
+        "toSceneName": "boss_frog",
+        "originSceneName": "lvl_Swamp"
+    },
+    {
+        "startingRegion": "Throne of the Frog King Exit to Flooded Fortress",
+        "endingRegion": "Flooded Fortress Exit to Throne of the Frog King",
+        "loadingZoneId": "d_frog_boss",
+        "toSceneName": "lvl_Swamp",
+        "originSceneName": "boss_frog"
+    },
+    {
+        "startingRegion": "Ceramic Manor Ancient Door",
+        "endingRegion": "Fire Avarice",
+        "loadingZoneId": "hod_anc_mansion",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": ""
+    },
+    {
+        "startingRegion": "Castle Lockstone Ancient Door",
+        "endingRegion": "Hookshot Avarice",
+        "loadingZoneId": "hod_anc_fortress",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": ""
+    },
+    {
+        "startingRegion": "Mushroom Dungeon Ancient Door",
+        "endingRegion": "Bomb Avarice",
+        "loadingZoneId": "hod_anc_forest",
+        "toSceneName": "lvl_HallOfDoors",
+        "originSceneName": ""
+    }
+]

--- a/ArchipelagoRandomizer/EntranceRandomizer.cs
+++ b/ArchipelagoRandomizer/EntranceRandomizer.cs
@@ -1,0 +1,306 @@
+using HarmonyLib;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using IC = DDoor.ItemChanger;
+
+namespace DDoor.ArchipelagoRandomizer;
+
+#nullable enable
+internal class EntranceRandomizer : MonoBehaviour
+{
+    private static EntranceRandomizer? instance;
+    public static EntranceRandomizer? Instance => instance;
+    private bool loadingIn = true;
+
+    private Dictionary<string, string>? entrancePairings = null;
+
+    internal Dictionary<string, string>? GetEntrancePairings()
+    {
+        if (entrancePairings == null)
+        {
+            JObject eP = (JObject)Archipelago.Instance.GetSlotData<object>("entrance_pairings");
+            entrancePairings = eP.ToObject<Dictionary<string, string>>();
+        }
+        return entrancePairings;
+    }
+
+    private readonly bool entranceRandomization = Archipelago.Instance.GetSlotData<long>("entrance_randomization") > 0; // Any value greater than 0 indicates entrance randomization
+
+    private void Awake()
+    {
+        instance = this;
+        SceneManager.sceneLoaded += RestorePlayerControl;
+    }
+
+    private void Destroy()
+    {
+        SceneManager.sceneLoaded -= RestorePlayerControl;
+    }
+
+    private void RestorePlayerControl(Scene scene, LoadSceneMode _)
+    {
+        if (SceneTransitions.IsSceneInRandomizedTransitions(scene.name))
+        {
+            PlayerGlobal.instance?.UnPauseInput_Cutscene();
+            GameSceneManager.instance.reloadPlayerScene = true;
+        }
+    }
+
+    private void AddFoundEntrance(string? loadingZoneId, string? sceneToLoad)
+    {
+        if (loadingZoneId != null && sceneToLoad != null)
+        {
+            SceneTransitions.SceneTransition? sceneTransition = SceneTransitions.GetOriginalSceneTransition(loadingZoneId, sceneToLoad);
+            if (sceneTransition != null)
+            {
+                string? entranceName = sceneTransition?.startingRegion;
+                if (entranceName != null)
+                {
+                    Archipelago.Instance.StoreFoundEntrance(entranceName);
+                }
+            }
+        }
+    }
+
+    [HarmonyPatch]
+    private class Patches
+    {
+        [HarmonyPatch(typeof(ShortcutDoor), nameof(ShortcutDoor.Awake))]
+        [HarmonyPostfix]
+        private static void PostShortcutDoorAwake(ShortcutDoor __instance)
+        {
+            if (Archipelago.Instance.IsConnected() && Instance != null && Instance.entranceRandomization)
+            {
+                DoorTrigger doorTrigger = __instance.doorTrigger;
+                SceneTransitions.SceneTransition? newSceneTransition = SceneTransitions.GetConnectedSceneTransition(doorTrigger.doorId, doorTrigger.sceneToLoad);
+                doorTrigger.sceneToLoad = newSceneTransition?.toSceneName;
+                doorTrigger.targetDoor = newSceneTransition?.loadingZoneId;
+            }
+            if (!IC.ItemChangerPlugin.TryGetPlacedItem(typeof(IC.DoorLocation), __instance.keyId, out IC.Item? item))
+            {
+                // If the door isn't randomized, don't disable it
+                return;
+            }
+            string doorName = IC.Predefined.predefinedLocations.First(kvp => kvp.Value.GetType() == typeof(IC.DoorLocation) && ((IC.DoorLocation)kvp.Value).UniqueId == __instance.keyId).Key;
+            if (Archipelago.Instance.IsConnected() && !Archipelago.Instance.Session.Items.AllItemsReceived.Any(apitem => apitem.ItemName == doorName))
+            {
+                __instance.unlocked = false;
+                if (__instance.hubDoor || __instance.keyId == "sdoor_tutorial")
+                {
+                    __instance.gameObject.SetActive(false);
+                    IC.BoolItem.closedHubDoors[__instance.keyId] = __instance.gameObject;
+                }
+
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(ShortcutDoor), nameof(ShortcutDoor.Trigger))]
+        [HarmonyBefore("deathsdoor.itemchanger")]
+        private static bool PreShortcutDoorTrigger(ShortcutDoor __instance)
+        {
+            //Borrowed directly from ItemChanger EXCEPT we apply checks for if we are entering Hall of Doors
+
+            if (!IC.ItemChangerPlugin.TryGetPlacedItem(typeof(IC.DoorLocation), __instance.keyId, out IC.Item? item))
+            {
+                return true;
+            }
+
+            // Original ItemChanger comment:
+            // The check can be collected from either side of the door; if this
+            // is not desirable - for instance if some form of transition rando
+            // has been applied - then you should also check isHub here.
+
+            string collectedKey = IC.DoorLocation.keyPrefix + __instance.keyId;
+            GameSave save = GameSave.GetSaveData();
+
+            // MODIFICATION TO ITEMCHANGER METHOD IN THIS CHECK
+            // Instead of only checking if the Door has not been collected,
+            // We want to check if it hasn't been collected AND one of three options
+            // 1. The door is unlocked already (for collecting in HoD when you already have the door)
+            // 2. We are not in Hall of Doors (for collecting in other levels)
+            // 3. It is the Grove of Spirits Door (for Chandler cutscene triggering GoS door)
+            if (!save.IsKeyUnlocked(collectedKey) && (__instance.unlocked || !SceneManager.GetSceneByName("lvl_HallOfDoors").isLoaded || __instance.keyId == IC.DoorLocation.groveDoorKey))
+            {
+                save.SetKeyState(collectedKey, true);
+                IC.CornerPopup.Show(item);
+                item.Trigger();
+
+                // Darwin normally only wakes up after defeating DFS.
+                // If the Grove of Spirits door is replaced by something
+                // else, this is problematic as it prevents the player from
+                // upgrading stats until potentially much later in the game.
+                //
+                // It would be preferrable to directly patch whatever is
+                // making the decision to wake Darwin up, but it has been
+                // very difficult to locate the exact object that does it.
+                //
+                // We set these keys after the Grove of Spirits door check
+                // because setting the DFS one earlier also disables the
+                // Chandler cutscene, which triggers the check in the first
+                // place.
+                if (__instance.keyId == IC.DoorLocation.groveDoorKey)
+                {
+                    save.SetKeyState("shop_prompted", true);
+                    save.SetKeyState(IC.DoorLocation.dfsKey, true);
+                }
+            }
+
+            if (!__instance.unlocked)
+            {
+                PlayerGlobal.instance.UnPauseInput();
+                PlayerGlobal.instance.UnPauseInput_Cutscene();
+            }
+
+            // If the door is already open, allow you to go through it anyway.
+            return __instance.unlocked;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(DoorTrigger), nameof(DoorTrigger.OnTriggerEnter))]
+        private static bool PreOnTriggerEnter(DoorTrigger __instance, Collider collider)
+        {
+            if (__instance.parentDoor == null) // All Shortcut Doors will have been modified on Awake
+            {
+                if (!__instance.triggered && Archipelago.Instance.IsConnected() && Instance != null && Instance.entranceRandomization)
+                {
+                    SceneTransitions.SceneTransition? newSceneTransition = SceneTransitions.GetConnectedSceneTransition(__instance.doorId, __instance.sceneToLoad);
+                    PlayerInputControl playerInputControl = collider.gameObject.GetComponent<PlayerInputControl>();
+                    if (newSceneTransition != null && !__instance.triggered && playerInputControl != null)
+                    {
+                        __instance.sceneToLoad = newSceneTransition?.toSceneName;
+                        __instance.targetDoor = newSceneTransition?.loadingZoneId;
+                        DoorTrigger.currentTargetDoor = newSceneTransition?.loadingZoneId;
+                        GameSave.GetSaveData().SetSpawnPoint(__instance.sceneToLoad, __instance.targetDoor);
+                        Instance.AddFoundEntrance(__instance.targetDoor, __instance.sceneToLoad);
+                    }
+                }
+                return true;
+            }
+            else
+            {
+                GameSave.GetSaveData().SetSpawnPoint(__instance.sceneToLoad, __instance.targetDoor);
+                Instance?.AddFoundEntrance(__instance.targetDoor, __instance.sceneToLoad);
+                // if have a ShortcutDoor, already have scene transition set
+                if (!__instance.triggered && SceneManager.GetSceneByName(__instance.sceneToLoad).isLoaded)
+                {
+                    DoorTrigger.currentTargetDoor = __instance.targetDoor;
+                    foreach (GameObject rootObject in SceneManager.GetSceneByName(__instance.sceneToLoad).GetRootGameObjects())
+                    {
+                        foreach (DoorTrigger doorTrigger in rootObject.GetComponentsInChildren<DoorTrigger>(true))
+                        {
+                            if (doorTrigger.doorId == __instance.targetDoor)
+                            {
+                                __instance.triggered = true;
+                                collider.gameObject.GetComponent<PlayerInputControl>()?.PauseInput(true);
+                                __instance.linkedLocalDoor = doorTrigger;
+                                doorTrigger.teleportThroughThisDoor();
+                                PlayerGlobal.instance.UnPauseInput_Cutscene();
+                                GameSceneManager.instance.reloadPlayerScene = true;
+                                return false;
+                            }
+                        }
+                    }
+                }
+                return true;
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(DoorTrigger), nameof(DoorTrigger.OnTriggerExit))]
+        private static void PostOnTriggerExit(DoorTrigger __instance)
+        {
+            GameSceneManager.instance.reloadPlayerScene = true;
+            PlayerGlobal.instance.UnPauseInput();
+            PlayerGlobal.instance.UnPauseInput_Cutscene();
+            if (__instance.parentDoor != null && !GameSave.GetSaveData().IsKeyUnlocked(__instance.parentDoor.keyId))
+            {
+                __instance.parentDoor.unlocked = false;
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(DoorTrigger), nameof(DoorTrigger.Awake))]
+        private static bool PreDoorTriggerAwake(DoorTrigger __instance)
+        {
+            // Prevent breaking when loading in when Door hasn't been made yet
+            if (Archipelago.Instance.IsConnected() && Instance != null && __instance.doorId != "" && !GameSave.GetSaveData().IsKeyUnlocked(DoorTrigger.currentTargetDoor) && Instance.entranceRandomization)
+            {
+                if (__instance.doorId == DoorTrigger.currentTargetDoor)
+                {
+                    if (PlayerGlobal.instance != null)
+                    {
+                        if (__instance.spawnPoint == null)
+                        {
+                            __instance.spawnPoint = __instance.gameObject.transform.GetChild(0);
+                        }
+                        PlayerGlobal.instance.SetPosition(__instance.spawnPoint.position, false, false);
+                        PlayerGlobal.instance.SetSafePos(__instance.spawnPoint.position);
+                        PlayerGlobal.instance.SetRotation(__instance.spawnPoint.rotation);
+                        DoorTrigger.currentTargetDoor = "";
+                        GameSceneManager.instance.reloadPlayerScene = true;
+                        PlayerGlobal.instance.UnPauseInput();
+                        PlayerGlobal.instance.UnPauseInput_Cutscene();
+                        __instance.parentDoor = __instance.gameObject.GetComponentInParent<ShortcutDoor>();
+                        Instance.loadingIn = false;
+                        return false;
+                    }
+                    else
+                    {
+                        __instance.retryInStart = true;
+                    }
+                }
+            }
+            return true;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(DoorTrigger), nameof(DoorTrigger.Start))]
+        private static bool PreDoorTriggerStart(DoorTrigger __instance)
+        {
+            // Prevent breaking when loading into Hall of Doors/from a save
+            if (Archipelago.Instance.IsConnected() && Instance != null && (__instance.retryInStart || Instance.loadingIn))
+            {
+                GameSceneManager.instance.reloadPlayerScene = true;
+                if (PlayerGlobal.instance != null && Instance.entranceRandomization)
+                {
+                    if (__instance.spawnPoint == null)
+                    {
+                        __instance.spawnPoint = __instance.gameObject.transform.GetChild(0);
+                    }
+                    PlayerGlobal.instance.SetPosition(__instance.spawnPoint.position, false, false);
+                    PlayerGlobal.instance.SetSafePos(__instance.spawnPoint.position);
+                    PlayerGlobal.instance.SetRotation(__instance.spawnPoint.rotation);
+                    DoorTrigger.currentTargetDoor = "";
+
+                    PlayerGlobal.instance.UnPauseInput();
+                    PlayerGlobal.instance.UnPauseInput_Cutscene();
+                    __instance.parentDoor = __instance.gameObject.GetComponentInParent<ShortcutDoor>();
+                    Instance.loadingIn = false;
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(ForestBuggy), nameof(ForestBuggy.loadNextScene))]
+        private static void PreForestBuggyloadNextScene(ForestBuggy __instance)
+        {
+            if (Archipelago.Instance.IsConnected() && Instance != null && Instance.entranceRandomization)
+            {
+                SceneTransitions.SceneTransition? sceneTransition = SceneTransitions.GetConnectedSceneTransition(__instance.doorId, __instance.targetScene);
+                if (sceneTransition != null)
+                {
+                    __instance.doorId = sceneTransition?.loadingZoneId;
+                    __instance.targetScene = sceneTransition?.toSceneName;
+                    Instance.AddFoundEntrance(__instance.doorId, __instance.targetScene);
+                }
+            }
+        }
+    }
+}
+#nullable disable

--- a/ArchipelagoRandomizer/ItemRandomizer.cs
+++ b/ArchipelagoRandomizer/ItemRandomizer.cs
@@ -274,7 +274,7 @@ internal class ItemRandomizer : MonoBehaviour
 	{
 		if (scene.name == "lvl_HallOfDoors")
 		{
-			Plugin.Logger.LogDebug("Triggering GoS door check");
+			Logger.Log("Triggering GoS door check");
 			if (icSaveData.UnnamedPlacements.ContainsKey("Grove of Spirits Door"))
 			{
 				icSaveData.UnnamedPlacements["Grove of Spirits Door"].Trigger();

--- a/ArchipelagoRandomizer/Logger.cs
+++ b/ArchipelagoRandomizer/Logger.cs
@@ -1,4 +1,6 @@
-﻿namespace DDoor.ArchipelagoRandomizer;
+﻿using System.Collections.Generic;
+
+namespace DDoor.ArchipelagoRandomizer;
 
 static class Logger
 {
@@ -15,5 +17,12 @@ static class Logger
 	public static void LogError(string message)
 	{
 		Plugin.Logger.LogError(message);
+	}
+	public static void LogList<T>(List<T> list)
+	{
+		foreach (T item in list)
+		{
+			Plugin.Logger.LogDebug(item.ToString());
+		}
 	}
 }

--- a/ArchipelagoRandomizer/SceneTransitions.cs
+++ b/ArchipelagoRandomizer/SceneTransitions.cs
@@ -1,0 +1,96 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace DDoor.ArchipelagoRandomizer;
+
+
+public static class SceneTransitions
+{
+    static SceneTransitions()
+    {
+        PopulateTransitionFromJson();
+    }
+    public readonly struct SceneTransition(
+            string startingRegion,
+            string endingRegion,
+            string loadingZoneId,
+            string toSceneName,
+            string originSceneName
+        )
+    {
+        public readonly string startingRegion = startingRegion;
+        public readonly string endingRegion = endingRegion;
+        public readonly string loadingZoneId = loadingZoneId;
+        public readonly string toSceneName = toSceneName;
+        public readonly string originSceneName = originSceneName;
+    }
+
+    private static List<SceneTransition> transitionData;
+
+    private static void PopulateTransitionFromJson()
+    {
+        Assembly assembly = Assembly.GetExecutingAssembly();
+        using StreamReader reader = new StreamReader(assembly.GetManifestResourceStream("DDoor.ArchipelagoRandomizer.Data.SceneTransitions.json"));
+        transitionData = JsonConvert.DeserializeObject<List<SceneTransition>>(reader.ReadToEnd());
+    }
+
+    internal static SceneTransition? GetThisSceneTransition(string loadingZoneId, string sceneName)
+    {
+        try
+        {
+            return transitionData.First(scene => scene.loadingZoneId.Equals(loadingZoneId.Replace("avarice_", ""),
+                StringComparison.OrdinalIgnoreCase)
+                && scene.toSceneName.Equals(sceneName, StringComparison.OrdinalIgnoreCase));
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    internal static SceneTransition? GetOriginalSceneTransition(string loadingZoneId, string sceneToLoad)
+    {
+        try
+        {
+            SceneTransition endingPoint = transitionData.First(scene => scene.loadingZoneId.Equals(loadingZoneId.Replace("avarice_", ""),
+                StringComparison.OrdinalIgnoreCase)
+                && scene.toSceneName.Equals(sceneToLoad, StringComparison.OrdinalIgnoreCase));
+            string exitName = endingPoint.endingRegion;
+            foreach (KeyValuePair<string, string> kvp in EntranceRandomizer.Instance.GetEntrancePairings())
+            {
+                if (kvp.Value == exitName)
+                {
+                    return transitionData.First(scene => scene.startingRegion == kvp.Key);
+                }
+            }
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    internal static SceneTransition? GetConnectedSceneTransition(string loadingZoneId, string sceneName)
+    {
+        SceneTransition? sceneTransition = GetThisSceneTransition(loadingZoneId, sceneName);
+        if (sceneTransition != null)
+        {
+            string entranceName = sceneTransition?.startingRegion;
+            if (EntranceRandomizer.Instance.GetEntrancePairings().TryGetValue(entranceName, out string exitName))
+            {
+                return transitionData.First(scene => scene.endingRegion == exitName);
+            }
+        }
+        return null;
+    }
+
+    internal static bool IsSceneInRandomizedTransitions(string sceneName) =>
+        transitionData.Any(scene => scene.toSceneName == sceneName);
+
+}
+#nullable disable

--- a/ArchipelagoRandomizer/UIManager.cs
+++ b/ArchipelagoRandomizer/UIManager.cs
@@ -77,12 +77,12 @@ internal class UIManager
 		}
 		catch (Exception e)
 		{
-			Plugin.Logger.LogInfo(e.Message);
+			Logger.Log(e.Message);
 		}
 		if (UpdateAvailable)
 		{
 			PathUtil.GetByPath("TitleScreen", "UI_PauseCanvas").AddComponent<NotificationDisplay>();
-			Plugin.Logger.LogInfo("Added notification to scene");
+			Logger.Log("Added notification to scene");
 		}
 
 		static bool IsNewerVersion(string newVersion)

--- a/DDArchipelagoRandomizer.csproj
+++ b/DDArchipelagoRandomizer.csproj
@@ -77,6 +77,7 @@
 	<ItemGroup>
     	<EmbeddedResource Include="ArchipelagoRandomizer/Data/Locations.json" />
     	<EmbeddedResource Include="ArchipelagoRandomizer/Data/Items.json" />
+		<EmbeddedResource Include="ArchipelagoRandomizer/Data/SceneTransitions.json" />
 		<EmbeddedResource Include="@(ItemChangerIcons)" />
   	</ItemGroup>
 


### PR DESCRIPTION
In conjunction with the latest version of the Death's Door apworld (attached here for testing), supports coupled and decoupled entrance randomization.
[deaths_door_zipped_apworld.zip](https://github.com/user-attachments/files/22447731/deaths_door_zipped_apworld.zip)
