### PR TITLE
Check if PlayerGlobal exists before first location used

### DIFF
--- a/ArchipelagoRandomizer/MapManager.cs
+++ b/ArchipelagoRandomizer/MapManager.cs
@@ -67,9 +67,9 @@ public class MapManager : MonoBehaviour
     private void UpdateCoordsIfNeeded()
     {
         float currentTime = Time.time;
-        PlayerCoords currentCoords = CurrentCoords();
         if (PlayerGlobal.instance)
         {
+            PlayerCoords currentCoords = CurrentCoords();
             if (currentTime >= lastSentTime + timeDelta)
             {
                 UpdateCoordinates(currentCoords);


### PR DESCRIPTION
I thought that I had already fixed this NullReferenceException, but apparently I put the check in the wrong place